### PR TITLE
Add web view for getting session cookie for error 401 handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,9 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit2_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit2_version"
 
+    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
+    implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"
 
     testImplementation "org.junit.jupiter:junit-jupiter:$junit5_version"
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.scopes.ActivityScoped
+import javax.inject.Singleton
 
 @Module
 @InstallIn(ActivityComponent::class)
@@ -105,5 +106,13 @@ class ActivityModule {
         filterTimeRangeRepository: FilterTimeRangeRepository
     ) = SetFilterDurationUseCase(
         filterTimeRangeRepository
+    )
+
+    @ActivityScoped
+    @Provides
+    fun provideSetCookieUseCase(
+        cookieRepository: CookieRepository
+    ) = SetCookieUseCase(
+        cookieRepository
     )
 }

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/di/ApplicationModule.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/di/ApplicationModule.kt
@@ -1,18 +1,17 @@
 package com.zeronfinity.cpfy.framework.di
 
 import android.app.Application
-import com.zeronfinity.core.repository.ContestRepository
-import com.zeronfinity.core.repository.FilterTimeRangeRepository
-import com.zeronfinity.core.repository.PlatformRepository
-import com.zeronfinity.core.repository.ServerContestInfoRepository
+import com.zeronfinity.core.repository.*
+import com.zeronfinity.core.usecase.GetCookieUseCase
 import com.zeronfinity.cpfy.CustomApplication
 import com.zeronfinity.cpfy.framework.network.clist.RetrofitClistApiClient
 import com.zeronfinity.cpfy.framework.network.clist.RetrofitClistApiInterface
 import com.zeronfinity.cpfy.model.ContestArrayList
-import com.zeronfinity.cpfy.model.FilterTimeRangeSharedPreference
+import com.zeronfinity.cpfy.model.FilterTimeRangeSharedPreferences
 import com.zeronfinity.cpfy.model.PlatformMap
 import com.zeronfinity.cpfy.model.ServerContestInfoClist
 import com.zeronfinity.cpfy.model.network.ClistNetworkCall
+import com.zeronfinity.cpfy.model.CookieSharedPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,7 +23,15 @@ import javax.inject.Singleton
 class ApplicationModule {
     @Singleton
     @Provides
-    fun provideClistApi(): RetrofitClistApiInterface = RetrofitClistApiClient.getClistApi()
+    fun provideClistClient(
+        application: Application,
+        getCookieUseCase: GetCookieUseCase
+    ): RetrofitClistApiClient =
+        RetrofitClistApiClient(application as CustomApplication, getCookieUseCase)
+
+    @Singleton
+    @Provides
+    fun provideClistApi(retrofitClistApiClient: RetrofitClistApiClient): RetrofitClistApiInterface = retrofitClistApiClient.getClistApi()
 
     @Singleton
     @Provides
@@ -47,5 +54,18 @@ class ApplicationModule {
     @Singleton
     @Provides
     fun provideFilterTimeRangeRepository(application: Application) =
-        FilterTimeRangeRepository(FilterTimeRangeSharedPreference(application as CustomApplication))
+        FilterTimeRangeRepository(FilterTimeRangeSharedPreferences(application as CustomApplication))
+
+    @Singleton
+    @Provides
+    fun provideCookieRepository(application: Application) =
+        CookieRepository(CookieSharedPreferences(application as CustomApplication))
+
+    @Singleton
+    @Provides
+    fun provideGetCookieUseCase(
+        cookieRepository: CookieRepository
+    ) = GetCookieUseCase(
+        cookieRepository
+    )
 }

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiClient.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiClient.kt
@@ -1,17 +1,58 @@
 package com.zeronfinity.cpfy.framework.network.clist
 
+import android.app.Application
+import android.util.Log
+import com.zeronfinity.core.usecase.GetCookieUseCase
+import com.zeronfinity.cpfy.R
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
 
-object RetrofitClistApiClient {
-    private const val apiBaseUrl = "https://clist.by"
+class RetrofitClistApiClient(
+    application: Application,
+    getCookieUseCase: GetCookieUseCase
+) {
+    private val LOG_TAG = RetrofitClistApiClient::class.simpleName
+
+    private val apiBaseUrl = application.getString(R.string.clist_base_url)
     private var retrofit: Retrofit
 
     init {
+        val interceptor = HttpLoggingInterceptor()
+        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+
+        val client: OkHttpClient = OkHttpClient.Builder().addNetworkInterceptor(interceptor)
+            .cookieJar(object : CookieJar {
+                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {}
+                override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                    val rawCookieString =
+                        getCookieUseCase(application.getString(R.string.clist_session_cookie))
+                    Log.d(LOG_TAG, "Raw cookie string: [$rawCookieString]")
+                    val cookieList = ArrayList<Cookie>()
+                    rawCookieString?.let {
+                        Cookie.parse(
+                            url,
+                            it
+                        )?.let { it1 -> cookieList.add(it1) }
+                    }
+                    return cookieList
+                }
+            })
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
         retrofit = Retrofit.Builder()
-                .baseUrl(apiBaseUrl)
-                .addConverterFactory(MoshiConverterFactory.create())
-                .build()
+            .baseUrl(apiBaseUrl)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .client(client)
+            .build()
     }
 
     fun getClistApi(): RetrofitClistApiInterface =

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiInterface.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiInterface.kt
@@ -9,6 +9,5 @@ import retrofit2.http.QueryMap
 interface RetrofitClistApiInterface {
 
     @GET("/api/v1/json/contest/")
-    suspend fun getContestData(@Query("username") userName: String, @Query("api_key") apiKey: String,
-                               @QueryMap params: Map<String,String>): Response<ClistServerResponse>
+    suspend fun getContestData(@Query("username") userName: String, @Query("api_key") apiKey: String, @QueryMap params: Map<String,String>): Response<ClistServerResponse>
 }

--- a/app/src/main/java/com/zeronfinity/cpfy/model/CookieSharedPreferences.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/CookieSharedPreferences.kt
@@ -1,0 +1,31 @@
+package com.zeronfinity.cpfy.model
+
+import android.app.Application
+import android.content.Context
+import com.zeronfinity.core.repository.CookieDataSource
+import com.zeronfinity.cpfy.R
+
+class CookieSharedPreferences(
+    private val application: Application
+) : CookieDataSource {
+    private val sharedPref = application.getSharedPreferences(
+        application.getString(R.string.shared_preferences_cookies),
+        Context.MODE_PRIVATE
+    )
+
+    override fun get(cookieTitle: String) =
+        sharedPref.getString(
+            cookieTitle,
+            null
+        )
+
+    override fun set(cookieTitle: String, rawCookieString: String) {
+        with(sharedPref.edit()) {
+            putString(
+                cookieTitle,
+                rawCookieString
+            )
+            commit()
+        }
+    }
+}

--- a/app/src/main/java/com/zeronfinity/cpfy/model/FilterTimeRangeSharedPreferences.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/FilterTimeRangeSharedPreferences.kt
@@ -7,7 +7,7 @@ import com.zeronfinity.cpfy.R
 import java.util.Calendar
 import java.util.Date
 
-class FilterTimeRangeSharedPreference(
+class FilterTimeRangeSharedPreferences(
     private val application: Application
 ) : FilterTimeRangeDataSource {
     private val sharedPref = application.getSharedPreferences(

--- a/app/src/main/java/com/zeronfinity/cpfy/view/FiltersFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/FiltersFragment.kt
@@ -3,6 +3,7 @@ package com.zeronfinity.cpfy.view
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -57,12 +58,21 @@ class FiltersFragment
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        Log.d(LOG_TAG, "onCreateView started")
         _binding = FragmentFiltersBinding.inflate(inflater, container, false)
         return binding.root
     }
 
+    override fun onStop() {
+        // TODO: Add condition to fetchContestList only if some parameter changed
+        contentListViewModel.fetchContestListAndPersist()
+        Log.d(LOG_TAG, "onStop ended")
+        super.onStop()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        Log.d(LOG_TAG, "onViewCreated started")
 
         binding.rvPlatforms.adapter = adapterPlatformFilters
         binding.rvPlatforms.layoutManager = GridLayoutManager(activity, 3)
@@ -82,8 +92,11 @@ class FiltersFragment
     }
 
     private fun observeContestListViewModel() {
-        contentListViewModel.contestListUpdatedLiveData.observe(viewLifecycleOwner, Observer {
-            refreshPlatformList()
+        contentListViewModel.contestListUpdatedLiveDataEv.observe(viewLifecycleOwner, Observer {
+            it.getContentIfNotHandled()?.let {
+                Log.d(LOG_TAG, "contestListUpdatedLiveData: refreshing platform list")
+                refreshPlatformList()
+            }
         })
     }
 

--- a/app/src/main/java/com/zeronfinity/cpfy/view/WebViewFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/WebViewFragment.kt
@@ -1,0 +1,108 @@
+package com.zeronfinity.cpfy.view
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.zeronfinity.cpfy.R
+import com.zeronfinity.cpfy.databinding.FragmentWebViewBinding
+import com.zeronfinity.cpfy.viewmodel.CookieViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import java.net.URL
+
+@AndroidEntryPoint
+class WebViewFragment : Fragment() {
+    private val LOG_TAG = WebViewFragment::class.simpleName
+
+    private var _binding: FragmentWebViewBinding? = null
+    private val binding get() = _binding!!
+
+    val args: WebViewFragmentArgs by navArgs()
+
+    private lateinit var cookieViewModel: CookieViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        Log.d(LOG_TAG, "onCreateView started")
+
+        _binding = FragmentWebViewBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Log.d(LOG_TAG, "onViewCreated started")
+
+        cookieViewModel = ViewModelProvider(this).get(CookieViewModel::class.java)
+
+        binding.webView.settings.builtInZoomControls = false
+        binding.webView.settings.javaScriptEnabled = true
+        binding.webView.settings.loadsImagesAutomatically = true
+        binding.webView.settings.userAgentString = getString(R.string.app_name)
+        binding.webView.settings.setGeolocationEnabled(true)
+
+        binding.webView.webViewClient = WebViewClient()
+
+        when (args.urlStringArg) {
+            getString(R.string.clist_login_url) -> {
+                binding.webView.loadUrl(args.urlStringArg)
+                Toast.makeText(
+                    activity?.applicationContext,
+                    "API limit reached!\nSign up or log into your own clist.by account to continue",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            else -> Log.e(LOG_TAG, "No url argument found!")
+        }
+
+        findNavController().addOnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
+                R.id.contestListFragment -> {
+                    Log.d(LOG_TAG, "addOnDestinationChangedListener called, destination: contestListFragment")
+                    getSessionCookieFromAppCookieManager(getString(R.string.clist_base_url))?.let {
+                        cookieViewModel.setCookie(
+                            getString(R.string.clist_session_cookie),
+                            it
+                        )
+                    }
+                }
+                else -> {
+                    Log.d(LOG_TAG, "addOnDestinationChangedListener: destination is not contestListFragment")
+                }
+            }
+        }
+    }
+
+    private fun getSessionCookieFromAppCookieManager(url: String): String? {
+        val cookieManager: CookieManager = CookieManager.getInstance()
+        val rawCookieHeader = cookieManager.getCookie(URL(url).host)
+        Log.d(LOG_TAG, "Raw Cookie Header: [$rawCookieHeader]")
+
+        rawCookieHeader?.let {
+            val cookieStrings = rawCookieHeader.split(";", " ").toTypedArray()
+
+            for (cookie in cookieStrings) {
+                val parts = cookie.split("=").toTypedArray()
+                if (parts[0] == "sessionid") {
+                    Log.d(LOG_TAG, "Session cookie: [$cookie]")
+                    return cookie
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/app/src/main/java/com/zeronfinity/cpfy/viewmodel/CookieViewModel.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/viewmodel/CookieViewModel.kt
@@ -1,0 +1,15 @@
+package com.zeronfinity.cpfy.viewmodel
+
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.ViewModel
+import com.zeronfinity.core.usecase.SetCookieUseCase
+
+class CookieViewModel @ViewModelInject constructor(
+    private val setCookieUseCase: SetCookieUseCase
+) : ViewModel() {
+    private val LOG_TAG = CookieViewModel::class.simpleName
+
+    fun setCookie(cookieTitle: String, rawCookieString: String) {
+        setCookieUseCase(cookieTitle, rawCookieString)
+    }
+}

--- a/app/src/main/java/com/zeronfinity/cpfy/viewmodel/helpers/Event.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/viewmodel/helpers/Event.kt
@@ -1,0 +1,27 @@
+package com.zeronfinity.cpfy.viewmodel.helpers
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ */
+open class Event<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peekContent(): T = content
+}

--- a/app/src/main/res/layout/fragment_web_view.xml
+++ b/app/src/main/res/layout/fragment_web_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -13,6 +13,9 @@
         <action
             android:id="@+id/action_contestListFragment_to_filtersFragment"
             app:destination="@id/filtersFragment" />
+        <action
+            android:id="@+id/action_contestListFragment_to_webViewFragment"
+            app:destination="@id/webViewFragment" />
     </fragment>
     <fragment
         android:id="@+id/filtersFragment"
@@ -30,5 +33,13 @@
             android:name="filterDurationEnumArg"
             app:argType="com.zeronfinity.core.repository.FilterTimeRangeRepository$FilterDurationEnum" />
     </dialog>
+    <fragment
+        android:id="@+id/webViewFragment"
+        android:name="com.zeronfinity.cpfy.view.WebViewFragment"
+        android:label="Web View" >
+        <argument
+            android:name="urlStringArg"
+            app:argType="string" />
+    </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
 
     <!-- shared preference file names and keys -->
     <string name="shared_preferences_filters">com.zeronfinity.cpfy.filters</string>
+    <string name="shared_preferences_cookies">com.zeronfinity.cpfy.cookies</string>
     <string name="s_pref_filters_key_start_time_lower_bound">start_time_lower_bound</string>
     <string name="s_pref_filters_key_start_time_upper_bound">start_time_upper_bound</string>
     <string name="s_pref_filters_key_end_time_lower_bound">end_time_lower_bound</string>
@@ -44,4 +45,9 @@
     <string name="minutes">Minutes</string>
     <string name="cancel">Cancel</string>
     <string name="okay">Okay</string>
+
+    <!-- clist strings -->
+    <string name="clist_base_url">https://clist.by</string>
+    <string name="clist_login_url">https://clist.by/login/</string>
+    <string name="clist_session_cookie">clist_session_cookie</string>
 </resources>

--- a/app/src/test/java/com/zeronfinity/cpfy/model/CookieSharedPreferencesTest.kt
+++ b/app/src/test/java/com/zeronfinity/cpfy/model/CookieSharedPreferencesTest.kt
@@ -1,0 +1,128 @@
+package com.zeronfinity.cpfy.model
+
+import android.app.Application
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+
+internal class CookieSharedPreferencesTest {
+
+    private val cookie = "cookie"
+    private val cookie2 = "cookie"
+    private val cookieTitle = "cookie_title"
+    private val sharedPreferencesCookies = "com.zeronfinity.cpfy.cookies"
+
+    private val applicationMock = mockk<Application>()
+    private val sharedPreferencesMock = mockk<SharedPreferences>()
+    private lateinit var sut: CookieSharedPreferences
+
+    @BeforeEach
+    internal fun setUp() {
+        every { applicationMock.getSharedPreferences(any(), any()) } returns sharedPreferencesMock
+        every { applicationMock.getString(any()) } returns sharedPreferencesCookies
+
+        every { sharedPreferencesMock.edit().commit() } answers { true }
+
+        sut = CookieSharedPreferences(applicationMock)
+    }
+
+    @Nested
+    @DisplayName("Given no preference set before")
+    inner class EmptyPreferences {
+        private val slotParamsStringKey = slot<String>()
+        private val slotParamsStringVal = slot<String>()
+        private val defList = mutableListOf<String?>()
+
+        @Test
+        @DisplayName("When get called, then correct parameters used")
+        fun get_correctParametersUsed() {
+            // Arrange
+            every {
+                sharedPreferencesMock.getString(
+                    capture(slotParamsStringKey),
+                    captureNullable(defList)
+                )
+            } answers { null }
+            // Act
+            sut.get(cookieTitle)
+            // Assert
+            assertAll(
+                Executable { assertEquals(cookieTitle, slotParamsStringKey.captured) },
+                Executable { assertNull(defList[0]) }
+            )
+        }
+
+        @Test
+        @DisplayName("When set called, then correct parameters used")
+        fun set_correctParametersUsed() {
+            // Arrange
+            every { sharedPreferencesMock.edit().putString(capture(slotParamsStringKey), capture(slotParamsStringVal)) } answers { nothing }
+            // Act
+            sut.set(cookieTitle, cookie)
+            // Assert
+            assertAll(
+                Executable { assertEquals(cookieTitle, slotParamsStringKey.captured) },
+                Executable { assertEquals(cookie, slotParamsStringVal.captured) },
+            )
+        }
+
+        @Test
+        @DisplayName("When get called, then null returned")
+        fun get_nullReturned() {
+            // Arrange
+            every { sharedPreferencesMock.getString(any(), any()) } answers { null }
+            // Act
+            val cookieActual = sut.get(cookieTitle)
+            // Assert
+            assertNull(cookieActual)
+        }
+    }
+
+    @Nested
+    @DisplayName("Given preference set before")
+    inner class AlreadySetPreferences {
+        private val slotParamsStringKey = slot<String>()
+        private val slotParamsStringVal = slot<String>()
+
+        @Test
+        @DisplayName("When get called, then last set cookie returned")
+        fun get_lastSetCookieReturned() {
+            // Arrange
+            every { sharedPreferencesMock.edit().putString(capture(slotParamsStringKey), capture(slotParamsStringVal)) } answers { nothing }
+            sut.set(cookieTitle, cookie)
+            every { sharedPreferencesMock.getString(cookieTitle, any()) } returns slotParamsStringVal.captured
+            // Act
+            val cookieActual = sut.get(cookieTitle)
+            // Assert
+            assertEquals(cookie, cookieActual)
+        }
+    }
+
+    @Nested
+    @DisplayName("Given preference set twice before")
+    inner class SetPreferencesTwice {
+        private val slotParamsStringKey = slot<String>()
+        private val slotParamsStringVal = slot<String>()
+
+        @Test
+        @DisplayName("When get called, then last set cookie returned")
+        fun get_lastSetCookieReturned() {
+            // Arrange
+            every { sharedPreferencesMock.edit().putString(capture(slotParamsStringKey), capture(slotParamsStringVal)) } answers { nothing }
+            sut.set(cookieTitle, cookie)
+            sut.set(cookieTitle, cookie2)
+            every { sharedPreferencesMock.getString(cookieTitle, any()) } returns slotParamsStringVal.captured
+            // Act
+            val cookieActual = sut.get(cookieTitle)
+            // Assert
+            assertEquals(cookie2, cookieActual)
+        }
+    }
+}

--- a/app/src/test/java/com/zeronfinity/cpfy/model/FilterTimeRangeSharedPreferencesTest.kt
+++ b/app/src/test/java/com/zeronfinity/cpfy/model/FilterTimeRangeSharedPreferencesTest.kt
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-internal class FilterTimeRangeSharedPreferenceTest {
+internal class FilterTimeRangeSharedPreferencesTest {
     private val simpleDateFormat = SimpleDateFormat(
         "dd-MM-yy HH:mm",
         Locale.getDefault()
@@ -38,7 +38,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
     private val applicationMock = mockk<Application>()
     private val sharedPreferencesMock = mockk<SharedPreferences>()
-    private lateinit var sut: FilterTimeRangeSharedPreference
+    private lateinit var sut: FilterTimeRangeSharedPreferences
 
     @BeforeEach
     internal fun setUp() {
@@ -47,7 +47,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         every { sharedPreferencesMock.edit().apply() } answers { nothing }
 
-        sut = FilterTimeRangeSharedPreference(applicationMock)
+        sut = FilterTimeRangeSharedPreferences(applicationMock)
     }
 
     @Nested
@@ -316,7 +316,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getStartTimeLowerBound called, then last set date returned")
-        fun getStartTimeLowerBound_currentDateReturned() {
+        fun getStartTimeLowerBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns startTimeLowerBoundLabel
             every { sharedPreferencesMock.edit().putLong(startTimeLowerBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -330,7 +330,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getStartTimeUpperBound called, then last set date returned")
-        fun getStartTimeUpperBound_currentDateReturned() {
+        fun getStartTimeUpperBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns startTimeUpperBoundLabel
             every { sharedPreferencesMock.edit().putLong(startTimeUpperBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -344,7 +344,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getEndTimeLowerBound called, then last set date returned")
-        fun getEndTimeLowerBound_currentDateReturned() {
+        fun getEndTimeLowerBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns endTimeLowerBoundLabel
             every { sharedPreferencesMock.edit().putLong(endTimeLowerBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -358,7 +358,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getEndTimeUpperBound called, then last set date returned")
-        fun getEndTimeUpperBound_currentDateReturned() {
+        fun getEndTimeUpperBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns endTimeUpperBoundLabel
             every { sharedPreferencesMock.edit().putLong(endTimeUpperBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -372,7 +372,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getDurationLowerBound called, then last set duration returned")
-        fun getDurationLowerBound_defaultDurationReturned() {
+        fun getDurationLowerBound_setDurationReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns durationLowerBoundLabel
             every { sharedPreferencesMock.edit().putInt(durationLowerBoundLabel, capture(slotParamsInt)) } answers { nothing }
@@ -386,7 +386,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getDurationUpperBound called, then last set duration returned")
-        fun getDurationUpperBound_defaultDurationReturned() {
+        fun getDurationUpperBound_setDurationReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns durationUpperBoundLabel
             every { sharedPreferencesMock.edit().putInt(durationUpperBoundLabel, capture(slotParamsInt)) } answers { nothing }
@@ -411,7 +411,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getStartTimeLowerBound called, then last set date returned")
-        fun getStartTimeLowerBound_currentDateReturned() {
+        fun getStartTimeLowerBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns startTimeLowerBoundLabel
             every { sharedPreferencesMock.edit().putLong(startTimeLowerBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -426,7 +426,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getStartTimeUpperBound called, then last set date returned")
-        fun getStartTimeUpperBound_currentDateReturned() {
+        fun getStartTimeUpperBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns startTimeUpperBoundLabel
             every { sharedPreferencesMock.edit().putLong(startTimeUpperBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -441,7 +441,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getEndTimeLowerBound called, then last set date returned")
-        fun getEndTimeLowerBound_currentDateReturned() {
+        fun getEndTimeLowerBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns endTimeLowerBoundLabel
             every { sharedPreferencesMock.edit().putLong(endTimeLowerBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -456,7 +456,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getEndTimeUpperBound called, then last set date returned")
-        fun getEndTimeUpperBound_currentDateReturned() {
+        fun getEndTimeUpperBound_setDateReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns endTimeUpperBoundLabel
             every { sharedPreferencesMock.edit().putLong(endTimeUpperBoundLabel, capture(slotParamsLong)) } answers { nothing }
@@ -471,7 +471,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getDurationLowerBound called, then last set duration returned")
-        fun getDurationLowerBound_defaultDurationReturned() {
+        fun getDurationLowerBound_setDurationReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns durationLowerBoundLabel
             every { sharedPreferencesMock.edit().putInt(durationLowerBoundLabel, capture(slotParamsInt)) } answers { nothing }
@@ -486,7 +486,7 @@ internal class FilterTimeRangeSharedPreferenceTest {
 
         @Test
         @DisplayName("When getDurationUpperBound called, then last set duration returned")
-        fun getDurationUpperBound_defaultDurationReturned() {
+        fun getDurationUpperBound_setDurationReturned() {
             // Arrange
             every { applicationMock.getString(any()) } returns durationUpperBoundLabel
             every { sharedPreferencesMock.edit().putInt(durationUpperBoundLabel, capture(slotParamsInt)) } answers { nothing }

--- a/core/src/main/java/com/zeronfinity/core/repository/CookieDataSource.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/CookieDataSource.kt
@@ -1,0 +1,7 @@
+package com.zeronfinity.core.repository
+
+interface CookieDataSource {
+    fun get(cookieTitle: String): String?
+
+    fun set(cookieTitle: String, rawCookieString: String)
+}

--- a/core/src/main/java/com/zeronfinity/core/repository/CookieRepository.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/CookieRepository.kt
@@ -1,0 +1,7 @@
+package com.zeronfinity.core.repository
+
+class CookieRepository(private val cookieDataSource: CookieDataSource) {
+    fun setCookie(cookieTitle: String, rawCookieString: String) = cookieDataSource.set(cookieTitle, rawCookieString)
+
+    fun getCookie(cookieTitle: String) = cookieDataSource.get(cookieTitle)
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/FetchServerContestInfoUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/FetchServerContestInfoUseCase.kt
@@ -13,6 +13,7 @@ class FetchServerContestInfoUseCase(
     sealed class Result {
         data class Success(val value: Boolean) : Result()
         data class Error(val errorMsg: String) : Result()
+        data class UnauthorizedError(val errorCode: Int) : Result()
     }
 
     suspend operator fun invoke(params: Map<String, String>): Result {
@@ -25,7 +26,10 @@ class FetchServerContestInfoUseCase(
             Result.Success(true)
         } else {
             if (serverContestInfoResponse.errorCode != null) {
-                Result.Error("Error ${serverContestInfoResponse.errorCode}: ${serverContestInfoResponse.errorDesc}")
+                when (serverContestInfoResponse.errorCode) {
+                    401 -> Result.UnauthorizedError(serverContestInfoResponse.errorCode)
+                    else -> Result.Error("Error ${serverContestInfoResponse.errorCode}: ${serverContestInfoResponse.errorDesc}")
+                }
             } else if (serverContestInfoResponse.errorDesc != null) {
                 Result.Error(serverContestInfoResponse.errorDesc)
             } else {

--- a/core/src/main/java/com/zeronfinity/core/usecase/GetCookieUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/GetCookieUseCase.kt
@@ -1,0 +1,7 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.CookieRepository
+
+class GetCookieUseCase(private val cookieRepository: CookieRepository) {
+    operator fun invoke(cookieTitle: String) = cookieRepository.getCookie(cookieTitle)
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/SetCookieUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/SetCookieUseCase.kt
@@ -1,0 +1,7 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.CookieRepository
+
+class SetCookieUseCase(private val cookieRepository: CookieRepository) {
+    operator fun invoke(cookieTitle: String, rawCookieString: String) = cookieRepository.setCookie(cookieTitle, rawCookieString)
+}


### PR DESCRIPTION
## Title

[Task: Add web view to get clist session id for error 401](https://github.com/Zeronfinity/CPfy/issues/36)

### Changes made

- Added web view launching when error code 401 is gotten from clist
- Saved session id from web view cookie and used for retrofit network call

### How does this PR address the issue

This PR will make it possible to use the app without using given API key in case of throttle issue

### Linked issues

Resolves #36