### PR TITLE
Fetch all platforms at start of app and always show all

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 4
-        versionName "0.2.1"
+        versionName "0.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/zeronfinity/cpfy/CustomApplication.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/CustomApplication.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class CustomApplication : Application() {
+    val isPlatformListFetched = false
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
@@ -59,12 +59,19 @@ class ActivityModule {
     @Provides
     fun provideFetchServerContestInfoUseCase(
         contestRepository: ContestRepository,
-        platformRepository: PlatformRepository,
         serverContestInfoRepository: ServerContestInfoRepository
     ) = FetchServerContestInfoUseCase(
         contestRepository,
-        platformRepository,
         serverContestInfoRepository
+    )
+
+    @Provides
+    fun provideFetchServerPlatformInfoUseCase(
+        platformRepository: PlatformRepository,
+        serverPlatformInfoRepository: ServerPlatformInfoRepository
+    ) = FetchServerPlatformInfoUseCase(
+        platformRepository,
+        serverPlatformInfoRepository
     )
     
     @Provides

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/di/ApplicationModule.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/di/ApplicationModule.kt
@@ -6,12 +6,8 @@ import com.zeronfinity.core.usecase.GetCookieUseCase
 import com.zeronfinity.cpfy.CustomApplication
 import com.zeronfinity.cpfy.framework.network.clist.RetrofitClistApiClient
 import com.zeronfinity.cpfy.framework.network.clist.RetrofitClistApiInterface
-import com.zeronfinity.cpfy.model.ContestArrayList
-import com.zeronfinity.cpfy.model.FilterTimeRangeSharedPreferences
-import com.zeronfinity.cpfy.model.PlatformMap
-import com.zeronfinity.cpfy.model.ServerContestInfoClist
+import com.zeronfinity.cpfy.model.*
 import com.zeronfinity.cpfy.model.network.ClistNetworkCall
-import com.zeronfinity.cpfy.model.CookieSharedPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -50,6 +46,11 @@ class ApplicationModule {
     @Provides
     fun provideServerContestInfoRepository(clistNetworkCall: ClistNetworkCall) =
         ServerContestInfoRepository(ServerContestInfoClist(clistNetworkCall))
+
+    @Singleton
+    @Provides
+    fun provideServerPlatformInfoRepository(application: Application, clistNetworkCall: ClistNetworkCall) =
+        ServerPlatformInfoRepository(ServerPlatformInfoClist(application as CustomApplication, clistNetworkCall))
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiInterface.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/network/clist/RetrofitClistApiInterface.kt
@@ -1,6 +1,7 @@
 package com.zeronfinity.cpfy.framework.network.clist
 
-import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponseContests
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponsePlatforms
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -9,5 +10,8 @@ import retrofit2.http.QueryMap
 interface RetrofitClistApiInterface {
 
     @GET("/api/v1/json/contest/")
-    suspend fun getContestData(@Query("username") userName: String, @Query("api_key") apiKey: String, @QueryMap params: Map<String,String>): Response<ClistServerResponse>
+    suspend fun getContestData(@Query("username") userName: String, @Query("api_key") apiKey: String, @QueryMap params: Map<String,String>): Response<ClistServerResponseContests>
+
+    @GET("/api/v1/json/resource/")
+    suspend fun getPlatformData(@Query("username") userName: String, @Query("api_key") apiKey: String): Response<ClistServerResponsePlatforms>
 }

--- a/app/src/main/java/com/zeronfinity/cpfy/model/ServerContestInfoClist.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/ServerContestInfoClist.kt
@@ -10,7 +10,7 @@ import com.zeronfinity.core.logger.logD
 import com.zeronfinity.core.repository.ServerContestInfoDataSource
 import com.zeronfinity.cpfy.framework.network.ResultWrapper
 import com.zeronfinity.cpfy.model.network.ClistNetworkCall
-import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponseContests
 
 class ServerContestInfoClist(
     private val clistNetworkCall: ClistNetworkCall
@@ -23,14 +23,14 @@ class ServerContestInfoClist(
         var platformList: MutableList<Platform>? = null
 
         val wrappedResult = clistNetworkCall.getContestData(params)
-        var clistServerResponse: ClistServerResponse? = null
+        var clistServerResponseContests: ClistServerResponseContests? = null
 
         logD("getInfo() -> wrappedResult: [$wrappedResult]")
 
         when (wrappedResult) {
             is ResultWrapper.Success -> {
                 responseStatus = SUCCESS
-                clistServerResponse = wrappedResult.value.body()
+                clistServerResponseContests = wrappedResult.value.body()
             }
             is ResultWrapper.GenericError -> {
                 if (wrappedResult.code != null) {
@@ -43,24 +43,24 @@ class ServerContestInfoClist(
             }
         }
 
-        logD("clistServerResponse: [" + clistServerResponse.toString() + "]")
+        logD("clistServerResponse: [" + clistServerResponseContests.toString() + "]")
 
-        if (clistServerResponse != null) {
-            val list = clistServerResponse.contestList
+        if (clistServerResponseContests != null) {
+            val list = clistServerResponseContests.contestList
             contestList = ArrayList()
             platformList = ArrayList()
 
             for (i in list.indices) {
                 contestList.add(list[i].toContest())
-                platformList.add(Platform(list[i].platformResource.platformName,
-                    "https://clist.by" + list[i].platformResource.iconUrlSegment,
-                    createPlatformShortName(list[i].platformResource.platformName)
+                platformList.add(Platform(list[i].platformResourceObject.platformName,
+                    "https://clist.by" + list[i].platformResourceObject.iconUrlSegment,
+                    createPlatformShortName(list[i].platformResourceObject.platformName)
                 ))
             }
         }
 
         logD("getInfo() -> contestList: [$contestList]")
-        logD("getInfo() -> platformList: [$contestList]")
+        logD("getInfo() -> platformList: [$platformList]")
 
         return ServerContestInfoResponse(responseStatus, errorCode, errorDesc, contestList, platformList)
     }

--- a/app/src/main/java/com/zeronfinity/cpfy/model/ServerPlatformInfoClist.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/ServerPlatformInfoClist.kt
@@ -1,0 +1,66 @@
+package com.zeronfinity.cpfy.model
+
+import android.app.Application
+import com.zeronfinity.core.entity.*
+import com.zeronfinity.core.entity.ServerPlatformInfoResponse.ResponseStatus.*
+import com.zeronfinity.core.logger.logD
+import com.zeronfinity.core.repository.ServerPlatformInfoDataSource
+import com.zeronfinity.cpfy.CustomApplication
+import com.zeronfinity.cpfy.framework.network.ResultWrapper
+import com.zeronfinity.cpfy.model.network.ClistNetworkCall
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponsePlatforms
+
+class ServerPlatformInfoClist(
+    private val application: CustomApplication,
+    private val clistNetworkCall: ClistNetworkCall
+) : ServerPlatformInfoDataSource {
+    override suspend fun getInfo(): ServerPlatformInfoResponse {
+        if (application.isPlatformListFetched) {
+            return ServerPlatformInfoResponse(NOT_FIRST_TIME, null, null, null)
+        }
+
+        var responseStatus = FAILURE
+        var errorCode: Int? = null
+        var errorDesc: String? = null
+        var platformList: MutableList<Platform>? = null
+
+        val wrappedResult = clistNetworkCall.getPlatformData()
+        var clistServerResponsePlatforms: ClistServerResponsePlatforms? = null
+
+        logD("getInfo() -> wrappedResult: [$wrappedResult]")
+
+        when (wrappedResult) {
+            is ResultWrapper.Success -> {
+                responseStatus = SUCCESS
+                clistServerResponsePlatforms = wrappedResult.value.body()
+            }
+            is ResultWrapper.GenericError -> {
+                if (wrappedResult.code != null) {
+                    errorCode = wrappedResult.code
+                    errorDesc = wrappedResult.error?.error_description
+                }
+            }
+            is ResultWrapper.NetworkError -> {
+                errorDesc = "Network Failure: IOException!"
+            }
+        }
+
+        logD("clistServerResponse: [${clistServerResponsePlatforms.toString()}]")
+
+        if (clistServerResponsePlatforms != null) {
+            val list = clistServerResponsePlatforms.platformList
+            platformList = ArrayList()
+
+            for (i in list.indices) {
+                platformList.add(Platform(list[i].platformName,
+                    "https://clist.by" + list[i].iconUrlSegment,
+                    createPlatformShortName(list[i].platformName)
+                ))
+            }
+        }
+
+        logD("getInfo() -> platformList: [$platformList]")
+
+        return ServerPlatformInfoResponse(responseStatus, errorCode, errorDesc, platformList)
+    }
+}

--- a/app/src/main/java/com/zeronfinity/cpfy/model/network/ClistNetworkCall.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/network/ClistNetworkCall.kt
@@ -7,7 +7,8 @@ import com.zeronfinity.cpfy.framework.network.ErrorResponse
 import com.zeronfinity.cpfy.framework.network.ResultWrapper
 import com.zeronfinity.cpfy.framework.network.clist.RetrofitClistApiInterface
 import com.zeronfinity.cpfy.framework.network.safeNetworkCall
-import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponseContests
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponsePlatforms
 import kotlinx.coroutines.Dispatchers
 import retrofit2.Response
 import java.net.HttpURLConnection
@@ -16,14 +17,33 @@ class ClistNetworkCall(
     private val application: CustomApplication,
     private val apiInterface: RetrofitClistApiInterface
 ) {
-    suspend fun getContestData(params: Map<String, String>): ResultWrapper<Response<ClistServerResponse>> {
-        logD("params: [" + params.toString() + "]")
+    suspend fun getContestData(params: Map<String, String>): ResultWrapper<Response<ClistServerResponseContests>> {
+        logD("getContestData() started -> params: [$params]")
 
         val wrappedResult = safeNetworkCall(Dispatchers.Default) {
             apiInterface.getContestData(
                 application.getString(R.string.clist_api_username),
                 application.getClistApiKey(),
                 params
+            )
+        }
+
+        if (wrappedResult is ResultWrapper.Success) {
+            if (wrappedResult.value.code() != HttpURLConnection.HTTP_OK) {
+                return ResultWrapper.GenericError(wrappedResult.value.code(), ErrorResponse(wrappedResult.value.message(), emptyMap()))
+            }
+        }
+
+        return wrappedResult
+    }
+
+    suspend fun getPlatformData(): ResultWrapper<Response<ClistServerResponsePlatforms>> {
+        logD("getPlatformData() started")
+
+        val wrappedResult = safeNetworkCall(Dispatchers.Default) {
+            apiInterface.getPlatformData(
+                application.getString(R.string.clist_api_username),
+                application.getClistApiKey()
             )
         }
 

--- a/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistContestObjectResponse.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistContestObjectResponse.kt
@@ -15,7 +15,7 @@ data class ClistContestObjectResponse (
     @field:Json(name = "href")
     var url: String,
     @field:Json(name = "resource")
-    var platformResource: ClistResourceResponse
+    var platformResourceObject: ClistResourceObjectResponse
 ) {
     companion object {
         const val apiDateFormat = "yyyy-MM-dd'T'HH:mm:ss"
@@ -27,7 +27,7 @@ data class ClistContestObjectResponse (
         return Contest(
             title,
             duration,
-            platformResource.platformName,
+            platformResourceObject.platformName,
             simpleDateFormatUtc.parse(start),
             simpleDateFormatUtc.parse(end),
             url

--- a/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistResourceObjectResponse.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistResourceObjectResponse.kt
@@ -2,7 +2,7 @@ package com.zeronfinity.cpfy.model.network.pojo
 
 import com.squareup.moshi.Json
 
-data class ClistResourceResponse (
+data class ClistResourceObjectResponse (
     @field:Json(name = "icon")
     var iconUrlSegment: String,
     @field:Json(name = "name")

--- a/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistServerResponseContests.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistServerResponseContests.kt
@@ -2,7 +2,7 @@ package com.zeronfinity.cpfy.model.network.pojo
 
 import com.squareup.moshi.Json
 
-data class ClistServerResponse(
+data class ClistServerResponseContests(
     @field:Json(name = "objects")
     var contestList: List<ClistContestObjectResponse>
 )

--- a/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistServerResponsePlatforms.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/model/network/pojo/ClistServerResponsePlatforms.kt
@@ -1,0 +1,8 @@
+package com.zeronfinity.cpfy.model.network.pojo
+
+import com.squareup.moshi.Json
+
+data class ClistServerResponsePlatforms(
+    @field:Json(name = "objects")
+    var platformList: List<ClistResourceObjectResponse>
+)

--- a/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
@@ -51,7 +51,8 @@ class ContestListFragment : Fragment() {
         viewModel = ViewModelProvider(requireActivity()).get(ContestListViewModel::class.java)
         observeViewModel()
 
-        viewModel.fetchContestListAndPersist()
+        viewModel.fetchContestList()
+        viewModel.fetchPlatformList()
     }
 
     private fun observeViewModel() {
@@ -67,6 +68,13 @@ class ContestListFragment : Fragment() {
         })
 
         viewModel.contestListUpdatedLiveDataEv.observe(viewLifecycleOwner, {
+            it.getContentIfNotHandled()?.let {
+                logD("contestListUpdatedLiveDataEv: refreshing adapterContestList")
+                adapterContestList.refreshContestList()
+            }
+        })
+
+        viewModel.platformListUpdatedLiveDataEv.observe(viewLifecycleOwner, {
             it.getContentIfNotHandled()?.let {
                 logD("contestListUpdatedLiveDataEv: refreshing adapterContestList")
                 adapterContestList.refreshContestList()

--- a/app/src/main/java/com/zeronfinity/cpfy/view/FiltersFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/FiltersFragment.kt
@@ -10,7 +10,6 @@ import android.widget.Button
 import android.widget.DatePicker
 import android.widget.TimePicker
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
@@ -67,7 +66,7 @@ class FiltersFragment
     override fun onStop() {
         logD("onStop() started -> isContestListRefreshRequired: [$isContestListRefreshRequired]")
         if (isContestListRefreshRequired) {
-            contentListViewModel.fetchContestListAndPersist()
+            contentListViewModel.fetchContestList()
         }
         super.onStop()
     }
@@ -94,7 +93,7 @@ class FiltersFragment
     }
 
     private fun observeContestListViewModel() {
-        contentListViewModel.contestListUpdatedLiveDataEv.observe(viewLifecycleOwner, {
+        contentListViewModel.platformListUpdatedLiveDataEv.observe(viewLifecycleOwner, {
             it.getContentIfNotHandled()?.let {
                 logD("contestListUpdatedLiveData: refreshing platform list")
                 refreshPlatformList()

--- a/app/src/test/java/com/zeronfinity/cpfy/model/ServerContestInfoClistTest.kt
+++ b/app/src/test/java/com/zeronfinity/cpfy/model/ServerContestInfoClistTest.kt
@@ -8,8 +8,8 @@ import com.zeronfinity.cpfy.framework.network.ErrorResponse
 import com.zeronfinity.cpfy.framework.network.ResultWrapper.*
 import com.zeronfinity.cpfy.model.network.ClistNetworkCall
 import com.zeronfinity.cpfy.model.network.pojo.ClistContestObjectResponse
-import com.zeronfinity.cpfy.model.network.pojo.ClistResourceResponse
-import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistResourceObjectResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponseContests
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
@@ -24,11 +24,11 @@ internal class ServerContestInfoClistTest {
     private val emptyParamsMap: Map<String, String> = mapOf()
     private val validParamsMap: Map<String, String> = mapOf("key1" to "val1", "key2" to "val2")
 
-    private val platformResource = ClistResourceResponse("/icon_url_segment", "platform_name")
+    private val platformResource = ClistResourceObjectResponse("/icon_url_segment", "platform_name")
     private val contestObject1 = ClistContestObjectResponse("title1", "2020-12-30T07:00:00", "2020-12-30T08:00:00", "url1", platformResource)
     private val contestObject2 = ClistContestObjectResponse("title2", "2020-12-20T08:00:00", "2020-12-22T08:00:00", "url2", platformResource)
 
-    private val serverResponseResult = Success(Response.success(ClistServerResponse(listOf(contestObject1, contestObject2))))
+    private val serverResponseResult = Success(Response.success(ClistServerResponseContests(listOf(contestObject1, contestObject2))))
     private val serverResponseExpectedForSuccess = ServerContestInfoResponse(
         SUCCESS,
         null,

--- a/app/src/test/java/com/zeronfinity/cpfy/model/network/ClistNetworkCallTest.kt
+++ b/app/src/test/java/com/zeronfinity/cpfy/model/network/ClistNetworkCallTest.kt
@@ -5,8 +5,8 @@ import com.zeronfinity.cpfy.CustomApplication
 import com.zeronfinity.cpfy.R
 import com.zeronfinity.cpfy.framework.network.ResultWrapper.*
 import com.zeronfinity.cpfy.model.network.pojo.ClistContestObjectResponse
-import com.zeronfinity.cpfy.model.network.pojo.ClistResourceResponse
-import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistResourceObjectResponse
+import com.zeronfinity.cpfy.model.network.pojo.ClistServerResponseContests
 import com.zeronfinity.cpfy.network.ClistApiClientMock
 import io.mockk.every
 import io.mockk.mockk
@@ -29,7 +29,7 @@ internal class ClistNetworkCallTest {
     private val emptyParamsMap: Map<String, String> = mapOf()
     private val validParamsMap: Map<String, String> = mapOf("key1" to "val1", "key2" to "val2")
 
-    private val platformResource = ClistResourceResponse("/icon_url_segment", "platform_name")
+    private val platformResource = ClistResourceObjectResponse("/icon_url_segment", "platform_name")
     private val contestObject1 = ClistContestObjectResponse(
         "title1",
         "2020-12-30T07:00:00",
@@ -46,7 +46,7 @@ internal class ClistNetworkCallTest {
     )
 
     private val emptyParamServerResponseJson = convertToJson(
-        ClistServerResponse(
+        ClistServerResponseContests(
             listOf(
                 contestObject1,
                 contestObject2
@@ -54,7 +54,7 @@ internal class ClistNetworkCallTest {
         )
     )
     private val validParamServerResponseJson = convertToJson(
-        ClistServerResponse(
+        ClistServerResponseContests(
             listOf(
                 contestObject1
             )
@@ -62,7 +62,7 @@ internal class ClistNetworkCallTest {
     )
 
     private val emptyParamResponseExpected = Response.success(
-        ClistServerResponse(
+        ClistServerResponseContests(
             listOf(
                 contestObject1,
                 contestObject2
@@ -70,7 +70,7 @@ internal class ClistNetworkCallTest {
         )
     )
     private val validParamResponseExpected = Response.success(
-        ClistServerResponse(
+        ClistServerResponseContests(
             listOf(
                 contestObject1
             )
@@ -347,6 +347,6 @@ internal class ClistNetworkCallTest {
 
     /* Helper functions */
 
-    private fun convertToJson(clistServerResponse: ClistServerResponse) =
-        Moshi.Builder().build().adapter(ClistServerResponse::class.java).toJson(clistServerResponse)
+    private fun convertToJson(clistServerResponseContests: ClistServerResponseContests) =
+        Moshi.Builder().build().adapter(ClistServerResponseContests::class.java).toJson(clistServerResponseContests)
 }

--- a/core/src/main/java/com/zeronfinity/core/entity/ServerPlatformInfoResponse.kt
+++ b/core/src/main/java/com/zeronfinity/core/entity/ServerPlatformInfoResponse.kt
@@ -1,0 +1,11 @@
+package com.zeronfinity.core.entity
+
+
+data class ServerPlatformInfoResponse (
+    val responseStatus: ResponseStatus,
+    val errorCode: Int?,
+    val errorDesc: String?,
+    val platformList: List<Platform>?
+) {
+    enum class ResponseStatus { SUCCESS, FAILURE, NOT_FIRST_TIME }
+}

--- a/core/src/main/java/com/zeronfinity/core/repository/ServerPlatformInfoDataSource.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/ServerPlatformInfoDataSource.kt
@@ -1,0 +1,7 @@
+package com.zeronfinity.core.repository
+
+import com.zeronfinity.core.entity.ServerPlatformInfoResponse
+
+interface ServerPlatformInfoDataSource {
+    suspend fun getInfo() : ServerPlatformInfoResponse
+}

--- a/core/src/main/java/com/zeronfinity/core/repository/ServerPlatformInfoRepository.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/ServerPlatformInfoRepository.kt
@@ -1,0 +1,5 @@
+package com.zeronfinity.core.repository
+
+class ServerPlatformInfoRepository(private val serverPlatformInfoDataSource: ServerPlatformInfoDataSource) {
+    suspend fun getPlatformInfo() = serverPlatformInfoDataSource.getInfo()
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/FetchServerContestInfoUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/FetchServerContestInfoUseCase.kt
@@ -1,13 +1,13 @@
 package com.zeronfinity.core.usecase
 
 import com.zeronfinity.core.entity.ServerContestInfoResponse
+import com.zeronfinity.core.entity.ServerContestInfoResponse.ResponseStatus.SUCCESS
 import com.zeronfinity.core.repository.ContestRepository
 import com.zeronfinity.core.repository.PlatformRepository
 import com.zeronfinity.core.repository.ServerContestInfoRepository
 
 class FetchServerContestInfoUseCase(
     private val contestRepository: ContestRepository,
-    private val platformRepository: PlatformRepository,
     private val serverContestInfoRepository: ServerContestInfoRepository
 ) {
     sealed class Result {
@@ -19,10 +19,9 @@ class FetchServerContestInfoUseCase(
     suspend operator fun invoke(params: Map<String, String>): Result {
         val serverContestInfoResponse = serverContestInfoRepository.getContestInfo(params)
 
-        return if (serverContestInfoResponse.responseStatus == ServerContestInfoResponse.ResponseStatus.SUCCESS) {
+        return if (serverContestInfoResponse.responseStatus == SUCCESS) {
             contestRepository.removeAllContests()
             serverContestInfoResponse.contestList?.let { contestRepository.addContestList(it) }
-            serverContestInfoResponse.platformList?.let { platformRepository.addPlatformList(it) }
             Result.Success(true)
         } else {
             if (serverContestInfoResponse.errorCode != null) {

--- a/core/src/main/java/com/zeronfinity/core/usecase/FetchServerPlatformInfoUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/FetchServerPlatformInfoUseCase.kt
@@ -1,0 +1,39 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.entity.ServerPlatformInfoResponse.ResponseStatus.NOT_FIRST_TIME
+import com.zeronfinity.core.entity.ServerPlatformInfoResponse.ResponseStatus.SUCCESS
+import com.zeronfinity.core.repository.PlatformRepository
+import com.zeronfinity.core.repository.ServerPlatformInfoRepository
+
+class FetchServerPlatformInfoUseCase(
+    private val platformRepository: PlatformRepository,
+    private val serverPlatformInfoRepository: ServerPlatformInfoRepository
+) {
+    sealed class Result {
+        data class Success(val isUpdateRequired: Boolean) : Result()
+        data class Error(val errorMsg: String) : Result()
+        data class UnauthorizedError(val errorCode: Int) : Result()
+    }
+
+    suspend operator fun invoke(): Result {
+        val serverPlatformInfoResponse = serverPlatformInfoRepository.getPlatformInfo()
+
+        return if (serverPlatformInfoResponse.responseStatus == SUCCESS) {
+            serverPlatformInfoResponse.platformList?.let { platformRepository.addPlatformList(it) }
+            Result.Success(true)
+        } else if (serverPlatformInfoResponse.responseStatus == NOT_FIRST_TIME) {
+            Result.Success(false)
+        } else {
+            if (serverPlatformInfoResponse.errorCode != null) {
+                when (serverPlatformInfoResponse.errorCode) {
+                    401 -> Result.UnauthorizedError(serverPlatformInfoResponse.errorCode)
+                    else -> Result.Error("Error ${serverPlatformInfoResponse.errorCode}: ${serverPlatformInfoResponse.errorDesc}")
+                }
+            } else if (serverPlatformInfoResponse.errorDesc != null) {
+                Result.Error(serverPlatformInfoResponse.errorDesc)
+            } else {
+                Result.Error("Unknown Network Error!")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Title

[Task: Fetch all platforms at start of app and always show all platforms in Filter screen](https://github.com/Zeronfinity/CPfy/issues/43)

### Changes made

-  fetched all platforms at start of app
- always show all platforms in filter screen

### Future work

Add separate screen to show all platforms and enable/disable. In filter screen, show only the platforms in current contest list.

### Linked issues

Resolves #43