### PR TITLE
Add filter functionality to use lower bound as start of current date

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.zeronfinity.cpfy"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 8
-        versionName "0.4.7"
+        versionCode 9
+        versionName "0.5.0"
 
         kapt {
             arguments {

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/di/ActivityModule.kt
@@ -11,6 +11,8 @@ import okhttp3.Cookie
 @Module
 @InstallIn(ActivityComponent::class)
 class ActivityModule {
+    /* platform use cases */
+
     @Provides
     fun provideDisablePlatformUseCase(
         platformRepository: PlatformRepository
@@ -45,6 +47,8 @@ class ActivityModule {
     ) = IsPlatformEnabledUseCase(
         platformRepository
     )
+
+    /* filter use cases */
 
     @Provides
     fun provideGetFilteredContestListUseCase(
@@ -141,6 +145,36 @@ class ActivityModule {
     ) = SetFilterSavedUseCase(
         filterTimeRangeRepository
     )
+
+    @Provides
+    fun provideIsFilterLowerBoundTodayUseCase(
+        filterTimeRangeRepository: FilterTimeRangeRepository
+    ) = IsFilterLowerBoundTodayUseCase(
+        filterTimeRangeRepository
+    )
+
+    @Provides
+    fun provideSetFilterLowerBoundTodayUseCase(
+        filterTimeRangeRepository: FilterTimeRangeRepository
+    ) = SetFilterLowerBoundTodayUseCase(
+        filterTimeRangeRepository
+    )
+
+    @Provides
+    fun provideGetFilterDaysAfterTodayUseCase(
+        filterTimeRangeRepository: FilterTimeRangeRepository
+    ) = GetFilterDaysAfterTodayUseCase(
+        filterTimeRangeRepository
+    )
+
+    @Provides
+    fun provideSetFilterDaysAfterTodayUseCase(
+        filterTimeRangeRepository: FilterTimeRangeRepository
+    ) = SetFilterDaysAfterTodayUseCase(
+        filterTimeRangeRepository
+    )
+
+    /* cookie use cases */
 
     @Provides
     fun provideSetCookieUseCase(

--- a/app/src/main/java/com/zeronfinity/cpfy/framework/implementations/FilterTimeRangeSharedPreferences.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/framework/implementations/FilterTimeRangeSharedPreferences.kt
@@ -19,7 +19,7 @@ class FilterTimeRangeSharedPreferences(
     )
     private val minDefaultDuration = DEFAULT_MIN_DURATION
     private val maxDefaultDuration = DEFAULT_MAX_DURATION
-    private val numberOfDaysBeforeContestsEnd = DEFAULT_DAYS_INTERVAL
+    private val numberOfDaysAfterLowerBound = DEFAULT_DAYS_INTERVAL
 
     override fun isSaved(): Boolean {
         return sharedPref.getBoolean(
@@ -47,10 +47,24 @@ class FilterTimeRangeSharedPreferences(
         return Date(date)
     }
 
+    override fun isStartTimeLowerBoundToday(): Boolean {
+        return sharedPref.getBoolean(
+            application.getString(R.string.s_pref_filters_key_start_time_lower_bound_today),
+            true
+        )
+    }
+
+    override fun getStartTimeDaysAfterToday(): Int {
+        return sharedPref.getInt(
+            application.getString(R.string.s_pref_filters_key_start_time_days_after_today),
+            numberOfDaysAfterLowerBound
+        )
+    }
+
     override fun getStartTimeUpperBound(): Date {
         val calendar = Calendar.getInstance()
         calendar.time = Date()
-        calendar.add(Calendar.DAY_OF_YEAR, numberOfDaysBeforeContestsEnd)
+        calendar.add(Calendar.DAY_OF_YEAR, numberOfDaysAfterLowerBound)
 
         val date = sharedPref.getLong(
             application.getString(R.string.s_pref_filters_key_start_time_upper_bound),
@@ -69,10 +83,24 @@ class FilterTimeRangeSharedPreferences(
         return Date(date)
     }
 
+    override fun isEndTimeLowerBoundToday(): Boolean {
+        return sharedPref.getBoolean(
+            application.getString(R.string.s_pref_filters_key_end_time_lower_bound_today),
+            true
+        )
+    }
+
+    override fun getEndTimeDaysAfterToday(): Int {
+        return sharedPref.getInt(
+            application.getString(R.string.s_pref_filters_key_end_time_days_after_today),
+            numberOfDaysAfterLowerBound
+        )
+    }
+
     override fun getEndTimeUpperBound(): Date {
         val calendar = Calendar.getInstance()
         calendar.time = Date()
-        calendar.add(Calendar.DAY_OF_YEAR, numberOfDaysBeforeContestsEnd)
+        calendar.add(Calendar.DAY_OF_YEAR, numberOfDaysAfterLowerBound)
 
         val date = sharedPref.getLong(
             application.getString(R.string.s_pref_filters_key_end_time_upper_bound),
@@ -106,6 +134,26 @@ class FilterTimeRangeSharedPreferences(
         }
     }
 
+    override fun setStartTimeLowerBoundToday(value: Boolean) {
+        with(sharedPref.edit()) {
+            putBoolean(
+                application.getString(R.string.s_pref_filters_key_start_time_lower_bound_today),
+                value
+            )
+            apply()
+        }
+    }
+
+    override fun setStartTimeDaysAfterToday(daysAfterToday: Int) {
+        with(sharedPref.edit()) {
+            putInt(
+                application.getString(R.string.s_pref_filters_key_start_time_days_after_today),
+                daysAfterToday
+            )
+            apply()
+        }
+    }
+
     override fun setStartTimeUpperBound(date: Date) {
         with(sharedPref.edit()) {
             putLong(
@@ -121,6 +169,26 @@ class FilterTimeRangeSharedPreferences(
             putLong(
                 application.getString(R.string.s_pref_filters_key_end_time_lower_bound),
                 date.time
+            )
+            apply()
+        }
+    }
+
+    override fun setEndTimeLowerBoundToday(value: Boolean) {
+        with(sharedPref.edit()) {
+            putBoolean(
+                application.getString(R.string.s_pref_filters_key_end_time_lower_bound_today),
+                value
+            )
+            apply()
+        }
+    }
+
+    override fun setEndTimeDaysAfterToday(daysAfterToday: Int) {
+        with(sharedPref.edit()) {
+            putInt(
+                application.getString(R.string.s_pref_filters_key_end_time_days_after_today),
+                daysAfterToday
             )
             apply()
         }

--- a/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
@@ -12,16 +12,17 @@ import com.zeronfinity.core.logger.logD
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_LOWER_BOUND
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_UPPER_BOUND
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeEnum.*
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.END_TIME
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.START_TIME
 import com.zeronfinity.cpfy.R
-import com.zeronfinity.cpfy.common.FILTER_DATE_TIME_FORMAT
 import com.zeronfinity.cpfy.databinding.FragmentContestListBinding
 import com.zeronfinity.cpfy.view.adapter.AdapterContestList
 import com.zeronfinity.cpfy.viewmodel.ContestListViewModel
 import com.zeronfinity.cpfy.viewmodel.FiltersViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
-import java.util.Locale
+import java.util.GregorianCalendar
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -147,44 +148,100 @@ class ContestListFragment : BaseFragment() {
     private fun isTimeFilterChanged(): Boolean {
         var isChanged = false
 
-        val startTimeLowerBound = filtersViewModel.getTimeFilters(START_TIME_LOWER_BOUND)
-        prevStartTimeLowerBound?.let {
-            if (prevStartTimeLowerBound != startTimeLowerBound) {
-                isChanged = true
+        if (filtersViewModel.isLowerBoundToday(START_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+            calendar.set(Calendar.MILLISECOND, 0)
+
+            prevStartTimeLowerBound?.let {
+                if (it.compareTo(calendar.time) != 0) {
+                    logD("isTimeFilterChanged() -> prevStartTimeLowerBound: [$it], calendar.time: [${calendar.time}]")
+                    isChanged = true
+                }
+            }
+
+            calendar.add(Calendar.DAY_OF_YEAR, filtersViewModel.getDaysAfterToday(START_TIME))
+
+            prevStartTimeUpperBound?.let {
+                if (it.compareTo(calendar.time) != 0) {
+                    logD("isTimeFilterChanged() -> prevStartTimeUpperBound: [$it], calendar.time: [${calendar.time}]")
+                    isChanged = true
+                }
+            }
+        } else {
+            val startTimeLowerBound = filtersViewModel.getTimeFilters(START_TIME_LOWER_BOUND)
+            prevStartTimeLowerBound?.let {
+                if (it.compareTo(startTimeLowerBound) != 0) {
+                    logD("isTimeFilterChanged() -> prevStartTimeLowerBound: [$it], startTimeLowerBound: [${startTimeLowerBound}]")
+                    isChanged = true
+                }
+            }
+
+            val startTimeUpperBound = filtersViewModel.getTimeFilters(START_TIME_UPPER_BOUND)
+            prevStartTimeUpperBound?.let {
+                if (it.compareTo(startTimeUpperBound) != 0) {
+                    logD("isTimeFilterChanged() -> prevStartTimeUpperBound: [$it], startTimeUpperBound: [${startTimeUpperBound}]")
+                    isChanged = true
+                }
             }
         }
 
-        val startTimeUpperBound = filtersViewModel.getTimeFilters(START_TIME_UPPER_BOUND)
-        prevStartTimeUpperBound?.let {
-            if (prevStartTimeUpperBound != startTimeUpperBound) {
-                isChanged = true
-            }
-        }
+        if (filtersViewModel.isLowerBoundToday(END_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+            calendar.set(Calendar.MILLISECOND, 0)
 
-        val endTimeLowerBound = filtersViewModel.getTimeFilters(END_TIME_LOWER_BOUND)
-        prevEndTimeLowerBound?.let {
-            if (prevEndTimeLowerBound != endTimeLowerBound) {
-                isChanged = true
+            prevEndTimeLowerBound?.let {
+                if (it.compareTo(calendar.time) != 0) {
+                    logD("isTimeFilterChanged() -> prevEndTimeLowerBound: [$it], calendar.time: [${calendar.time}]")
+                    isChanged = true
+                }
             }
-        }
 
-        val endTimeUpperBound = filtersViewModel.getTimeFilters(END_TIME_UPPER_BOUND)
-        prevEndTimeUpperBound?.let {
-            if (prevEndTimeUpperBound != endTimeUpperBound) {
-                isChanged = true
+            calendar.add(Calendar.DAY_OF_YEAR, filtersViewModel.getDaysAfterToday(START_TIME))
+
+            prevEndTimeUpperBound?.let {
+                if (it.compareTo(calendar.time) != 0) {
+                    logD("isTimeFilterChanged() -> prevEndTimeUpperBound: [$it], calendar.time: [${calendar.time}]")
+                    isChanged = true
+                }
+            }
+        } else {
+            val endTimeLowerBound = filtersViewModel.getTimeFilters(END_TIME_LOWER_BOUND)
+            prevEndTimeLowerBound?.let {
+                if (it.compareTo(endTimeLowerBound) != 0) {
+                    logD("isTimeFilterChanged() -> prevEndTimeLowerBound: [$it], endTimeLowerBound: [${endTimeLowerBound}]")
+                    isChanged = true
+                }
+            }
+
+            val endTimeUpperBound = filtersViewModel.getTimeFilters(END_TIME_UPPER_BOUND)
+            prevEndTimeUpperBound?.let {
+                if (it.compareTo(endTimeUpperBound) != 0) {
+                    logD("isTimeFilterChanged() -> prevEndTimeUpperBound: [$it], endTimeUpperBound: [${endTimeUpperBound}]")
+                    isChanged = true
+                }
             }
         }
 
         val durationLowerBound = filtersViewModel.getDurationFilters(DURATION_LOWER_BOUND)
         prevDurationLowerBound?.let {
-            if (prevDurationLowerBound != durationLowerBound) {
+            if (it.compareTo(durationLowerBound) != 0) {
+                logD("isTimeFilterChanged() -> prevDurationLowerBound: [$it], durationLowerBound: [${durationLowerBound}]")
                 isChanged = true
             }
         }
 
         val durationUpperBound = filtersViewModel.getDurationFilters(DURATION_UPPER_BOUND)
         prevDurationUpperBound?.let {
-            if (prevDurationUpperBound != durationUpperBound) {
+            if (it.compareTo(durationUpperBound) != 0) {
+                logD("isTimeFilterChanged() -> prevDurationUpperBound: [$it], durationUpperBound: [${durationUpperBound}]")
                 isChanged = true
             }
         }
@@ -195,10 +252,41 @@ class ContestListFragment : BaseFragment() {
     }
 
     private fun setPrevTimesToCurrentValues() {
-        prevStartTimeLowerBound = filtersViewModel.getTimeFilters(START_TIME_LOWER_BOUND)
-        prevStartTimeUpperBound = filtersViewModel.getTimeFilters(START_TIME_UPPER_BOUND)
-        prevEndTimeLowerBound = filtersViewModel.getTimeFilters(END_TIME_LOWER_BOUND)
-        prevEndTimeUpperBound = filtersViewModel.getTimeFilters(END_TIME_UPPER_BOUND)
+        if (filtersViewModel.isLowerBoundToday(START_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+            calendar.set(Calendar.MILLISECOND, 0)
+
+            prevStartTimeLowerBound = calendar.time
+
+            calendar.add(Calendar.DAY_OF_YEAR, filtersViewModel.getDaysAfterToday(START_TIME))
+            prevStartTimeUpperBound = calendar.time
+
+        } else {
+            prevStartTimeLowerBound = filtersViewModel.getTimeFilters(START_TIME_LOWER_BOUND)
+            prevStartTimeUpperBound = filtersViewModel.getTimeFilters(START_TIME_UPPER_BOUND)
+        }
+
+        if (filtersViewModel.isLowerBoundToday(END_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+            calendar.set(Calendar.MILLISECOND, 0)
+
+            prevEndTimeLowerBound = calendar.time
+
+            calendar.add(Calendar.DAY_OF_YEAR, filtersViewModel.getDaysAfterToday(END_TIME))
+            prevEndTimeUpperBound = calendar.time
+        } else {
+            prevEndTimeLowerBound = filtersViewModel.getTimeFilters(END_TIME_LOWER_BOUND)
+            prevEndTimeUpperBound = filtersViewModel.getTimeFilters(END_TIME_UPPER_BOUND)
+        }
+
         prevDurationLowerBound = filtersViewModel.getDurationFilters(DURATION_LOWER_BOUND)
         prevDurationUpperBound = filtersViewModel.getDurationFilters(DURATION_UPPER_BOUND)
     }

--- a/app/src/main/java/com/zeronfinity/cpfy/view/DayPickerDiaFrag.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/DayPickerDiaFrag.kt
@@ -1,0 +1,72 @@
+package com.zeronfinity.cpfy.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.zeronfinity.core.repository.FilterTimeRangeRepository
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.END_TIME
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.START_TIME
+import com.zeronfinity.cpfy.databinding.FragmentDayPickerBinding
+import com.zeronfinity.cpfy.databinding.FragmentDurationPickerBinding
+import com.zeronfinity.cpfy.viewmodel.FiltersViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class DayPickerDiaFrag : DialogFragment() {
+    private var _binding: FragmentDayPickerBinding? = null
+    private val binding get() = _binding!!
+
+    private val args: DayPickerDiaFragArgs by navArgs()
+
+    private lateinit var filtersViewModel: FiltersViewModel
+
+    private var days = 7
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDayPickerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        filtersViewModel = ViewModelProvider(requireActivity()).get(FiltersViewModel::class.java)
+
+        days = filtersViewModel.getDaysAfterToday(args.filterTimeTypeEnumArg)
+
+        binding.numPickerDays.minValue = 0
+        binding.numPickerDays.maxValue = 365
+        binding.numPickerDays.value = days
+
+        binding.btnCancel.setOnClickListener {
+            findNavController().popBackStack()
+        }
+
+        binding.btnOk.setOnClickListener {
+            when (args.filterTimeTypeEnumArg) {
+                START_TIME -> filtersViewModel.setStartTimeDaysAfterToday(binding.numPickerDays.value)
+                END_TIME -> filtersViewModel.setEndTimeDaysAfterToday(binding.numPickerDays.value)
+            }
+
+            findNavController().popBackStack()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_day_picker.xml
+++ b/app/src/main/res/layout/fragment_day_picker.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvDaysLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:text="@string/days"
+        android:textColor="@color/secondaryDarkColor"
+        app:layout_constraintBottom_toTopOf="@+id/numPickerDays"
+        app:layout_constraintEnd_toEndOf="@+id/numPickerDays"
+        app:layout_constraintStart_toStartOf="@+id/numPickerDays"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <NumberPicker
+        android:id="@+id/numPickerDays"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:foregroundTint="@color/secondaryColor"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvDaysLabel" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" />
+
+    <Button
+        android:id="@+id/btnCancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:backgroundTint="@color/secondaryColor"
+        android:text="@string/cancel"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btnOk"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/guideline" />
+
+    <Button
+        android:id="@+id/btnOk"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:backgroundTint="@color/secondaryColor"
+        android:text="@string/okay"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/btnCancel"
+        app:layout_constraintTop_toBottomOf="@+id/guideline" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_filters.xml
+++ b/app/src/main/res/layout/fragment_filters.xml
@@ -21,213 +21,286 @@
             android:textSize="@dimen/fragment_filter_header_text_size"
             android:textStyle="bold" />
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:baselineAligned="false">
+            android:layout_height="wrap_content">
 
-            <LinearLayout
+            <!-- start time stuff -->
+
+            <Button
+                android:id="@+id/btnStartTimeLowerBound"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
                 android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical">
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe1"
+                app:layout_constraintTop_toTopOf="parent" />
 
-                <Button
-                    android:id="@+id/btnStartTimeLowerBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
-
-                <Button
-                    android:id="@+id/btnEndTimeLowerBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
-
-                <Button
-                    android:id="@+id/btnDurationLowerBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/tvStartTimeLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/start_time_tv_label"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:id="@+id/tvEndTimeLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/end_time_tv_label"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:id="@+id/tvDurationLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/duration_tv_label"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/less_than_or_equal_to"
-                    android:textColor="@color/primaryTextColor"
-                    app:layout_gravity="center" />
-            </LinearLayout>
-
-            <LinearLayout
+            <CheckBox
+                android:id="@+id/cbStartTime"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
                 android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:translationX="-4dp"
+                android:translationY="-5dp"
+                android:text="@string/today"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintTop_toBottomOf="@+id/btnStartTimeLowerBound" />
 
-                <Button
-                    android:id="@+id/btnStartTimeUpperBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
+            <TextView
+                android:id="@+id/tvLe1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintEnd_toStartOf="@+id/tvStartTimeLabel"
+                app:layout_constraintStart_toEndOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintTop_toTopOf="@+id/btnStartTimeLowerBound" />
 
-                <Button
-                    android:id="@+id/btnEndTimeUpperBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
+            <TextView
+                android:id="@+id/tvStartTimeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/start_time_tv_label"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintEnd_toStartOf="@+id/tvLe2"
+                app:layout_constraintStart_toEndOf="@+id/tvLe1"
+                app:layout_constraintTop_toTopOf="@+id/btnStartTimeLowerBound" />
 
-                <Button
-                    android:id="@+id/btnDurationUpperBound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/fragment_filter_horizontal_gap"
-                    android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
-                    android:backgroundTint="@color/secondaryColor" />
-            </LinearLayout>
-        </LinearLayout>
+            <TextView
+                android:id="@+id/tvLe2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintEnd_toStartOf="@+id/btnStartTimeUpperBound"
+                app:layout_constraintStart_toEndOf="@+id/tvStartTimeLabel"
+                app:layout_constraintTop_toTopOf="@+id/btnStartTimeLowerBound" />
+
+            <Button
+                android:id="@+id/btnStartTimeUpperBound"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnStartTimeLowerBound"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe2"
+                app:layout_constraintTop_toTopOf="@+id/btnStartTimeLowerBound" />
+
+            <TextView
+                android:id="@+id/tvDaysAfterTodaySt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:textColor="@color/primaryColor"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@+id/tvDaysAfterTodayLabelSt"
+                app:layout_constraintTop_toBottomOf="@+id/btnStartTimeUpperBound" />
+
+            <TextView
+                android:id="@+id/tvDaysAfterTodayLabelSt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="day(s) after"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintEnd_toEndOf="@+id/btnStartTimeUpperBound"
+                app:layout_constraintTop_toBottomOf="@+id/btnStartTimeUpperBound" />
+
+            <!-- end time stuff -->
+
+            <Button
+                android:id="@+id/btnEndTimeLowerBound"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe3"
+                app:layout_constraintTop_toBottomOf="@+id/cbStartTime" />
+
+            <CheckBox
+                android:id="@+id/cbEndTime"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:translationX="-4dp"
+                android:translationY="-5dp"
+                android:text="@string/today"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="@+id/btnEndTimeLowerBound"
+                app:layout_constraintTop_toBottomOf="@+id/btnEndTimeLowerBound" />
+
+            <TextView
+                android:id="@+id/tvLe3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnEndTimeLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvLe1"
+                app:layout_constraintStart_toStartOf="@+id/tvLe1"
+                app:layout_constraintTop_toTopOf="@+id/btnEndTimeLowerBound" />
+
+            <TextView
+                android:id="@+id/tvEndTimeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/end_time_tv_label"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnEndTimeLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvStartTimeLabel"
+                app:layout_constraintStart_toStartOf="@+id/tvStartTimeLabel"
+                app:layout_constraintTop_toTopOf="@+id/btnEndTimeLowerBound" />
+
+            <TextView
+                android:id="@+id/tvLe4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnEndTimeLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvLe2"
+                app:layout_constraintStart_toStartOf="@+id/tvLe2"
+                app:layout_constraintTop_toTopOf="@+id/btnEndTimeLowerBound" />
+
+            <Button
+                android:id="@+id/btnEndTimeUpperBound"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnEndTimeLowerBound"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe4"
+                app:layout_constraintTop_toTopOf="@+id/btnEndTimeLowerBound" />
+
+            <TextView
+                android:id="@+id/tvDaysAfterTodayEd"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:textColor="@color/primaryColor"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@+id/tvDaysAfterTodayLabelEd"
+                app:layout_constraintTop_toBottomOf="@+id/btnEndTimeUpperBound" />
+
+            <TextView
+                android:id="@+id/tvDaysAfterTodayLabelEd"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="day(s) after"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintEnd_toEndOf="@+id/btnEndTimeUpperBound"
+                app:layout_constraintTop_toBottomOf="@+id/btnEndTimeUpperBound" />
+
+            <!-- duration stuff -->
+
+            <Button
+                android:id="@+id/btnDurationLowerBound"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe5"
+                app:layout_constraintTop_toBottomOf="@+id/cbEndTime" />
+
+            <TextView
+                android:id="@+id/tvLe5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnDurationLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvLe1"
+                app:layout_constraintStart_toStartOf="@+id/tvLe1"
+                app:layout_constraintTop_toTopOf="@+id/btnDurationLowerBound" />
+
+            <TextView
+                android:id="@+id/tvDurationLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/duration_tv_label"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnDurationLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvStartTimeLabel"
+                app:layout_constraintStart_toStartOf="@+id/tvStartTimeLabel"
+                app:layout_constraintTop_toTopOf="@+id/btnDurationLowerBound" />
+
+            <TextView
+                android:id="@+id/tvLe6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:gravity="center"
+                android:text="@string/less_than_or_equal_to"
+                android:textColor="@color/primaryTextColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnDurationLowerBound"
+                app:layout_constraintEnd_toEndOf="@+id/tvLe2"
+                app:layout_constraintStart_toStartOf="@+id/tvLe2"
+                app:layout_constraintTop_toTopOf="@+id/btnDurationLowerBound" />
+
+            <Button
+                android:id="@+id/btnDurationUpperBound"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fragment_filter_horizontal_gap_half"
+                android:layout_marginEnd="@dimen/fragment_filter_horizontal_gap_half"
+                android:backgroundTint="@color/secondaryColor"
+                app:layout_constraintBottom_toBottomOf="@+id/btnDurationLowerBound"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvLe6"
+                app:layout_constraintTop_toTopOf="@+id/btnDurationLowerBound" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView
             android:id="@+id/tvPlatformsLabel"

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -27,6 +27,9 @@
         <action
             android:id="@+id/action_filtersFragment_to_durationPickerDiaFrag"
             app:destination="@id/durationPickerDiaFrag" />
+        <action
+            android:id="@+id/action_filtersFragment_to_dayPickerDiaFrag"
+            app:destination="@id/dayPickerDiaFrag" />
     </fragment>
     <dialog
         android:id="@+id/durationPickerDiaFrag"
@@ -50,4 +53,12 @@
         android:name="com.zeronfinity.cpfy.view.ClipboardFragment"
         android:label="Clipboard"
         tools:layout="@layout/fragment_clipboard" />
+    <dialog
+        android:id="@+id/dayPickerDiaFrag"
+        android:name="com.zeronfinity.cpfy.view.DayPickerDiaFrag"
+        android:label="DayPickerDiaFrag">
+        <argument
+            android:name="filterTimeTypeEnumArg"
+            app:argType="com.zeronfinity.core.repository.FilterTimeRangeRepository$FilterTimeTypeEnum" />
+    </dialog>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,8 +35,12 @@
     <string name="shared_preferences_cookies">com.zeronfinity.cpfy.cookies</string>
     <string name="s_pref_filters_is_saved">is_saved</string>
     <string name="s_pref_filters_key_start_time_lower_bound">start_time_lower_bound</string>
+    <string name="s_pref_filters_key_start_time_lower_bound_today">start_time_lower_bound_today</string>
+    <string name="s_pref_filters_key_start_time_days_after_today">start_time_days_after_today</string>
     <string name="s_pref_filters_key_start_time_upper_bound">start_time_upper_bound</string>
     <string name="s_pref_filters_key_end_time_lower_bound">end_time_lower_bound</string>
+    <string name="s_pref_filters_key_end_time_lower_bound_today">end_time_lower_bound_today</string>
+    <string name="s_pref_filters_key_end_time_days_after_today">end_time_days_after_today</string>
     <string name="s_pref_filters_key_end_time_upper_bound">end_time_upper_bound</string>
     <string name="s_pref_filters_key_duration_lower_bound">duration_lower_bound</string>
     <string name="s_pref_filters_key_duration_upper_bound">duration_upper_bound</string>
@@ -57,4 +61,5 @@
     <string name="copy">Copy</string>
     <string name="link_colon">Link:</string>
     <string name="contests">contests</string>
+    <string name="today">Today</string>
 </resources>

--- a/app/src/test/java/com/zeronfinity/cpfy/framework/implementations/FilterTimeRangeSharedPreferencesTest.kt
+++ b/app/src/test/java/com/zeronfinity/cpfy/framework/implementations/FilterTimeRangeSharedPreferencesTest.kt
@@ -2,6 +2,7 @@ package com.zeronfinity.cpfy.framework.implementations
 
 import android.app.Application
 import android.content.SharedPreferences
+import com.zeronfinity.cpfy.common.DEFAULT_DAYS_INTERVAL
 import com.zeronfinity.cpfy.framework.implementations.FilterTimeRangeSharedPreferences
 import io.mockk.every
 import io.mockk.mockk
@@ -29,10 +30,16 @@ internal class FilterTimeRangeSharedPreferencesTest {
 
     private val defaultDuration = 7 * 24 * 60 * 60
 
+    private val defaultDaysAfterToday = DEFAULT_DAYS_INTERVAL
+
     private val sharedPreferencesFilter = "com.zeronfinity.cpfy.filters"
     private val startTimeLowerBoundLabel = "start_time_lower_bound"
+    private val startTimeLowerBoundTodayLabel = "start_time_lower_bound_today"
+    private val startTimeDaysAfterTodayLabel = "start_time_days_after_today"
     private val startTimeUpperBoundLabel = "start_time_upper_bound"
     private val endTimeLowerBoundLabel = "end_time_lower_bound"
+    private val endTimeLowerBoundTodayLabel = "end_time_lower_bound_today"
+    private val endTimeDaysAfterTodayLabel = "end_time_days_after_today"
     private val endTimeUpperBoundLabel = "end_time_upper_bound"
     private val durationLowerBoundLabel = "duration_lower_bound"
     private val durationUpperBoundLabel = "duration_upper_bound"
@@ -54,6 +61,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
     @Nested
     @DisplayName("Given no preference set before")
     inner class EmptyPreferences {
+        private val slotParamsBool = slot<Boolean>()
         private val slotParamsInt = slot<Int>()
         private val slotParamsLong = slot<Long>()
         private val slotParamsString = slot<String>()
@@ -71,8 +79,32 @@ internal class FilterTimeRangeSharedPreferencesTest {
         }
 
         @Test
+        @DisplayName("When isStartTimeLowerBoundToday called, then correct parameters used")
+        fun isStartTimeLowerBoundToday_correctParametersUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getBoolean(capture(slotParamsString), capture(slotParamsBool)) } answers { true }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            sut.isStartTimeLowerBoundToday()
+            // Assert
+            assertEquals(startTimeLowerBoundTodayLabel, slotParamsString.captured)
+        }
+
+        @Test
+        @DisplayName("When getStartTimeDaysAfterToday called, then correct parameters used")
+        fun getStartTimeDaysAfterToday_correctParametersUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getInt(capture(slotParamsString), capture(slotParamsInt)) } answers { defaultDaysAfterToday }
+            every { applicationMock.getString(any()) } returns startTimeDaysAfterTodayLabel
+            // Act
+            sut.getStartTimeDaysAfterToday()
+            // Assert
+            assertEquals(startTimeDaysAfterTodayLabel, slotParamsString.captured)
+        }
+
+        @Test
         @DisplayName("When getStartTimeUpperBound called, then correct parameters used")
-        fun getStartTimeUpperBound_correctValueSetInPreference() {
+        fun getStartTimeUpperBound_correctParametersUsed() {
             // Arrange
             every { sharedPreferencesMock.getLong(capture(slotParamsString), capture(slotParamsLong)) } answers { dateExpected.time }
             every { applicationMock.getString(any()) } returns startTimeUpperBoundLabel
@@ -84,7 +116,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
 
         @Test
         @DisplayName("When getEndTimeLowerBound called, then correct parameters used")
-        fun getEndTimeLowerBound_correctValueSetInPreference() {
+        fun getEndTimeLowerBound_correctParametersUsed() {
             // Arrange
             every { sharedPreferencesMock.getLong(capture(slotParamsString), capture(slotParamsLong)) } answers { dateExpected.time }
             every { applicationMock.getString(any()) } returns endTimeLowerBoundLabel
@@ -95,8 +127,32 @@ internal class FilterTimeRangeSharedPreferencesTest {
         }
 
         @Test
+        @DisplayName("When isEndTimeLowerBoundToday called, then correct parameters used")
+        fun isEndTimeLowerBoundToday_correctParametersUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getBoolean(capture(slotParamsString), capture(slotParamsBool)) } answers { true }
+            every { applicationMock.getString(any()) } returns endTimeLowerBoundTodayLabel
+            // Act
+            sut.isEndTimeLowerBoundToday()
+            // Assert
+            assertEquals(endTimeLowerBoundTodayLabel, slotParamsString.captured)
+        }
+
+        @Test
+        @DisplayName("When getEndTimeDaysAfterToday called, then correct parameters used")
+        fun getEndTimeDaysAfterToday_correctParametersUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getInt(capture(slotParamsString), capture(slotParamsInt)) } answers { defaultDaysAfterToday }
+            every { applicationMock.getString(any()) } returns endTimeDaysAfterTodayLabel
+            // Act
+            sut.getEndTimeDaysAfterToday()
+            // Assert
+            assertEquals(endTimeDaysAfterTodayLabel, slotParamsString.captured)
+        }
+
+        @Test
         @DisplayName("When getEndTimeUpperBound called, then correct parameters used")
-        fun getEndTimeUpperBound_correctValueSetInPreference() {
+        fun getEndTimeUpperBound_correctParametersUsed() {
             // Arrange
             every { sharedPreferencesMock.getLong(capture(slotParamsString), capture(slotParamsLong)) } answers { dateExpected.time }
             every { applicationMock.getString(any()) } returns endTimeUpperBoundLabel
@@ -108,7 +164,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
 
         @Test
         @DisplayName("When getDurationLowerBound called, then correct parameters used")
-        fun getDurationLowerBound_correctValueSetInPreference() {
+        fun getDurationLowerBound_correctParametersUsed() {
             // Arrange
             every { sharedPreferencesMock.getInt(capture(slotParamsString), capture(slotParamsInt)) } answers { durationExpected }
             every { applicationMock.getString(any()) } returns durationLowerBoundLabel
@@ -120,7 +176,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
 
         @Test
         @DisplayName("When getDurationUpperBound called, then correct parameters used")
-        fun getDurationUpperBound_correctValueSetInPreference() {
+        fun getDurationUpperBound_correctParametersUsed() {
             // Arrange
             every { sharedPreferencesMock.getInt(capture(slotParamsString), capture(slotParamsInt)) } answers { durationExpected }
             every { applicationMock.getString(any()) } returns durationUpperBoundLabel
@@ -144,6 +200,38 @@ internal class FilterTimeRangeSharedPreferencesTest {
             assertAll(
                 Executable { assertEquals(startTimeLowerBoundLabel, slotParamsString.captured) },
                 Executable { assertEquals(dateExpected, dateActual) }
+            )
+        }
+
+        @Test
+        @DisplayName("When setStartTimeLowerBoundToday called, then correct parameters used")
+        fun setStartTimeLowerBoundToday_correctParametersUsed() {
+            // Arrange
+            val valueExpected = true
+            every { sharedPreferencesMock.edit().putBoolean(capture(slotParamsString), capture(slotParamsBool)) } answers { nothing }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            sut.setStartTimeLowerBoundToday(valueExpected)
+            // Assert
+            assertAll(
+                Executable { assertEquals(startTimeLowerBoundTodayLabel, slotParamsString.captured) },
+                Executable { assertEquals(valueExpected, slotParamsBool.captured) }
+            )
+        }
+
+        @Test
+        @DisplayName("When setStartTimeDaysAfterToday called, then correct parameters used")
+        fun setStartTimeDaysAfterToday_correctParametersUsed() {
+            // Arrange
+            val resultExpected = 7
+            every { sharedPreferencesMock.edit().putInt(capture(slotParamsString), capture(slotParamsInt)) } answers { nothing }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            sut.setStartTimeDaysAfterToday(resultExpected)
+            // Assert
+            assertAll(
+                Executable { assertEquals(startTimeLowerBoundTodayLabel, slotParamsString.captured) },
+                Executable { assertEquals(resultExpected, slotParamsInt.captured) }
             )
         }
 
@@ -178,6 +266,38 @@ internal class FilterTimeRangeSharedPreferencesTest {
             assertAll(
                 Executable { assertEquals(endTimeLowerBoundLabel, slotParamsString.captured) },
                 Executable { assertEquals(dateExpected, dateActual) }
+            )
+        }
+
+        @Test
+        @DisplayName("When setEndTimeLowerBoundToday called, then correct parameters used")
+        fun setEndTimeLowerBoundToday_correctParametersUsed() {
+            // Arrange
+            val valueExpected = true
+            every { sharedPreferencesMock.edit().putBoolean(capture(slotParamsString), capture(slotParamsBool)) } answers { nothing }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            sut.setEndTimeLowerBoundToday(valueExpected)
+            // Assert
+            assertAll(
+                Executable { assertEquals(startTimeLowerBoundTodayLabel, slotParamsString.captured) },
+                Executable { assertEquals(valueExpected, slotParamsBool.captured) }
+            )
+        }
+
+        @Test
+        @DisplayName("When setEndTimeDaysAfterToday called, then correct parameters used")
+        fun setEndTimeDaysAfterToday_correctParametersUsed() {
+            // Arrange
+            val resultExpected = 7
+            every { sharedPreferencesMock.edit().putInt(capture(slotParamsString), capture(slotParamsInt)) } answers { nothing }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            sut.setEndTimeDaysAfterToday(resultExpected)
+            // Assert
+            assertAll(
+                Executable { assertEquals(startTimeLowerBoundTodayLabel, slotParamsString.captured) },
+                Executable { assertEquals(resultExpected, slotParamsInt.captured) }
             )
         }
 
@@ -242,6 +362,30 @@ internal class FilterTimeRangeSharedPreferencesTest {
         }
 
         @Test
+        @DisplayName("When isStartTimeLowerBoundToday called, then true returned")
+        fun isStartTimeLowerBoundToday_trueReturned() {
+            // Arrange
+            every { sharedPreferencesMock.getBoolean(startTimeLowerBoundTodayLabel, any()) } answers { true }
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            // Act
+            val value = sut.isStartTimeLowerBoundToday()
+            // Assert
+            assertEquals(true, value)
+        }
+
+        @Test
+        @DisplayName("When getStartTimeDaysAfterToday called, then defaultDaysAfterToday used")
+        fun getStartTimeDaysAfterToday_defaultDaysAfterTodayUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getInt(startTimeDaysAfterTodayLabel, any()) } answers { defaultDaysAfterToday }
+            every { applicationMock.getString(any()) } returns startTimeDaysAfterTodayLabel
+            // Act
+            val result = sut.getStartTimeDaysAfterToday()
+            // Assert
+            assertEquals(defaultDaysAfterToday, result)
+        }
+
+        @Test
         @DisplayName("When getStartTimeUpperBound called, then current date returned")
         fun getStartTimeUpperBound_currentDateReturned() {
             // Arrange
@@ -265,6 +409,30 @@ internal class FilterTimeRangeSharedPreferencesTest {
             val date = sut.getEndTimeLowerBound()
             // Assert
             assertEquals(currentDate, date)
+        }
+
+        @Test
+        @DisplayName("When isEndTimeLowerBoundToday called, then true returned")
+        fun isEndTimeLowerBoundToday_trueReturned() {
+            // Arrange
+            every { sharedPreferencesMock.getBoolean(endTimeLowerBoundTodayLabel, any()) } answers { true }
+            every { applicationMock.getString(any()) } returns endTimeLowerBoundTodayLabel
+            // Act
+            val value = sut.isEndTimeLowerBoundToday()
+            // Assert
+            assertEquals(true, value)
+        }
+
+        @Test
+        @DisplayName("When getEndTimeDaysAfterToday called, then defaultDaysAfterToday used")
+        fun getEndTimeDaysAfterToday_defaultDaysAfterTodayUsed() {
+            // Arrange
+            every { sharedPreferencesMock.getInt(endTimeDaysAfterTodayLabel, any()) } answers { defaultDaysAfterToday }
+            every { applicationMock.getString(any()) } returns endTimeDaysAfterTodayLabel
+            // Act
+            val result = sut.getEndTimeDaysAfterToday()
+            // Assert
+            assertEquals(defaultDaysAfterToday, result)
         }
 
         @Test
@@ -308,6 +476,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
     @Nested
     @DisplayName("Given preference set before")
     inner class AlreadySetPreferences {
+        private val slotParamsBool = slot<Boolean>()
         private val slotParamsInt = slot<Int>()
         private val slotParamsLong = slot<Long>()
 
@@ -327,6 +496,36 @@ internal class FilterTimeRangeSharedPreferencesTest {
             val dateActual = sut.getStartTimeLowerBound()
             // Assert
             assertEquals(dateExpected, dateActual)
+        }
+
+        @Test
+        @DisplayName("When isStartTimeLowerBoundToday called, then last set value returned")
+        fun isStartTimeLowerBoundToday_setValueReturned() {
+            // Arrange
+            val valueExpected = true
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            every { sharedPreferencesMock.edit().putBoolean(startTimeLowerBoundTodayLabel, capture(slotParamsBool)) } answers { nothing }
+            sut.setStartTimeLowerBoundToday(valueExpected)
+            every { sharedPreferencesMock.getBoolean(startTimeLowerBoundTodayLabel, any()) } returns slotParamsBool.captured
+            // Act
+            val valueActual = sut.isStartTimeLowerBoundToday()
+            // Assert
+            assertEquals(valueExpected, valueActual)
+        }
+
+        @Test
+        @DisplayName("When getStartTimeDaysAfterToday called, then last set value returned")
+        fun getStartTimeDaysAfterToday_setValueReturned() {
+            // Arrange
+            val resultExpected = 7
+            every { applicationMock.getString(any()) } returns startTimeDaysAfterTodayLabel
+            every { sharedPreferencesMock.edit().putInt(startTimeDaysAfterTodayLabel, capture(slotParamsInt)) } answers { nothing }
+            sut.setStartTimeDaysAfterToday(resultExpected)
+            every { sharedPreferencesMock.getInt(startTimeDaysAfterTodayLabel, any()) } returns slotParamsInt.captured
+            // Act
+            val resultActual = sut.getStartTimeDaysAfterToday()
+            // Assert
+            assertEquals(resultExpected, resultActual)
         }
 
         @Test
@@ -355,6 +554,36 @@ internal class FilterTimeRangeSharedPreferencesTest {
             val dateActual = sut.getEndTimeLowerBound()
             // Assert
             assertEquals(dateExpected, dateActual)
+        }
+
+        @Test
+        @DisplayName("When isEndTimeLowerBoundToday called, then last set value returned")
+        fun isEndTimeLowerBoundToday_setValueReturned() {
+            // Arrange
+            val valueExpected = true
+            every { applicationMock.getString(any()) } returns endTimeLowerBoundTodayLabel
+            every { sharedPreferencesMock.edit().putBoolean(endTimeLowerBoundTodayLabel, capture(slotParamsBool)) } answers { nothing }
+            sut.setEndTimeLowerBoundToday(valueExpected)
+            every { sharedPreferencesMock.getBoolean(endTimeLowerBoundTodayLabel, any()) } returns slotParamsBool.captured
+            // Act
+            val valueActual = sut.isEndTimeLowerBoundToday()
+            // Assert
+            assertEquals(valueExpected, valueActual)
+        }
+
+        @Test
+        @DisplayName("When getEndTimeDaysAfterToday called, then last set value returned")
+        fun getEndTimeDaysAfterToday_setValueReturned() {
+            // Arrange
+            val resultExpected = 7
+            every { applicationMock.getString(any()) } returns startTimeDaysAfterTodayLabel
+            every { sharedPreferencesMock.edit().putInt(startTimeDaysAfterTodayLabel, capture(slotParamsInt)) } answers { nothing }
+            sut.setEndTimeDaysAfterToday(resultExpected)
+            every { sharedPreferencesMock.getInt(startTimeDaysAfterTodayLabel, any()) } returns slotParamsInt.captured
+            // Act
+            val resultActual = sut.getEndTimeDaysAfterToday()
+            // Assert
+            assertEquals(resultExpected, resultActual)
         }
 
         @Test
@@ -403,6 +632,7 @@ internal class FilterTimeRangeSharedPreferencesTest {
     @Nested
     @DisplayName("Given preference set twice before")
     inner class SetPreferencesTwice {
+        private val slotParamsBool = slot<Boolean>()
         private val slotParamsInt = slot<Int>()
         private val slotParamsLong = slot<Long>()
 
@@ -423,6 +653,40 @@ internal class FilterTimeRangeSharedPreferencesTest {
             val dateActual = sut.getStartTimeLowerBound()
             // Assert
             assertEquals(dateExpected2, dateActual)
+        }
+
+        @Test
+        @DisplayName("When isStartTimeLowerBoundToday called, then last set value returned")
+        fun isStartTimeLowerBoundToday_setValueReturned() {
+            // Arrange
+            val valueExpected = true
+            val valueExpected2 = false
+            every { applicationMock.getString(any()) } returns startTimeLowerBoundTodayLabel
+            every { sharedPreferencesMock.edit().putBoolean(startTimeLowerBoundTodayLabel, capture(slotParamsBool)) } answers { nothing }
+            sut.setStartTimeLowerBoundToday(valueExpected)
+            sut.setStartTimeLowerBoundToday(valueExpected2)
+            every { sharedPreferencesMock.getBoolean(startTimeLowerBoundTodayLabel, any()) } returns slotParamsBool.captured
+            // Act
+            val valueActual = sut.isStartTimeLowerBoundToday()
+            // Assert
+            assertEquals(valueExpected2, valueActual)
+        }
+
+        @Test
+        @DisplayName("When getStartTimeDaysAfterToday called, then last set value returned")
+        fun getStartTimeDaysAfterToday_setValueReturned() {
+            // Arrange
+            val resultExpected = 7
+            val resultExpected2 = 1
+            every { applicationMock.getString(any()) } returns startTimeDaysAfterTodayLabel
+            every { sharedPreferencesMock.edit().putInt(startTimeDaysAfterTodayLabel, capture(slotParamsInt)) } answers { nothing }
+            sut.setStartTimeDaysAfterToday(resultExpected)
+            sut.setStartTimeDaysAfterToday(resultExpected2)
+            every { sharedPreferencesMock.getInt(startTimeDaysAfterTodayLabel, any()) } returns slotParamsInt.captured
+            // Act
+            val resultActual = sut.getStartTimeDaysAfterToday()
+            // Assert
+            assertEquals(resultExpected2, resultActual)
         }
 
         @Test
@@ -453,6 +717,40 @@ internal class FilterTimeRangeSharedPreferencesTest {
             val dateActual = sut.getEndTimeLowerBound()
             // Assert
             assertEquals(dateExpected2, dateActual)
+        }
+
+        @Test
+        @DisplayName("When isEndTimeLowerBoundToday called, then last set value returned")
+        fun isEndTimeLowerBoundToday_setValueReturned() {
+            // Arrange
+            val valueExpected = true
+            val valueExpected2 = false
+            every { applicationMock.getString(any()) } returns endTimeLowerBoundTodayLabel
+            every { sharedPreferencesMock.edit().putBoolean(endTimeLowerBoundTodayLabel, capture(slotParamsBool)) } answers { nothing }
+            sut.setEndTimeLowerBoundToday(valueExpected)
+            sut.setEndTimeLowerBoundToday(valueExpected2)
+            every { sharedPreferencesMock.getBoolean(endTimeLowerBoundTodayLabel, any()) } returns slotParamsBool.captured
+            // Act
+            val valueActual = sut.isEndTimeLowerBoundToday()
+            // Assert
+            assertEquals(valueExpected2, valueActual)
+        }
+
+        @Test
+        @DisplayName("When getEndTimeDaysAfterToday called, then last set value returned")
+        fun getEndTimeDaysAfterToday_setValueReturned() {
+            // Arrange
+            val resultExpected = 7
+            val resultExpected2 = 1
+            every { applicationMock.getString(any()) } returns endTimeDaysAfterTodayLabel
+            every { sharedPreferencesMock.edit().putInt(endTimeDaysAfterTodayLabel, capture(slotParamsInt)) } answers { nothing }
+            sut.setEndTimeDaysAfterToday(resultExpected)
+            sut.setEndTimeDaysAfterToday(resultExpected2)
+            every { sharedPreferencesMock.getInt(endTimeDaysAfterTodayLabel, any()) } returns slotParamsInt.captured
+            // Act
+            val resultActual = sut.getEndTimeDaysAfterToday()
+            // Assert
+            assertEquals(resultExpected2, resultActual)
         }
 
         @Test

--- a/core/src/main/java/com/zeronfinity/core/repository/FilterTimeRangeDataSource.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/FilterTimeRangeDataSource.kt
@@ -9,9 +9,17 @@ interface FilterTimeRangeDataSource {
 
     fun getStartTimeLowerBound(): Date
 
+    fun isStartTimeLowerBoundToday(): Boolean
+
+    fun getStartTimeDaysAfterToday(): Int
+
     fun getStartTimeUpperBound(): Date
 
     fun getEndTimeLowerBound(): Date
+
+    fun isEndTimeLowerBoundToday(): Boolean
+
+    fun getEndTimeDaysAfterToday(): Int
 
     fun getEndTimeUpperBound(): Date
 
@@ -21,9 +29,17 @@ interface FilterTimeRangeDataSource {
 
     fun setStartTimeLowerBound(date: Date)
 
+    fun setStartTimeLowerBoundToday(value: Boolean)
+
+    fun setStartTimeDaysAfterToday(daysAfterToday: Int)
+
     fun setStartTimeUpperBound(date: Date)
 
     fun setEndTimeLowerBound(date: Date)
+
+    fun setEndTimeLowerBoundToday(value: Boolean)
+
+    fun setEndTimeDaysAfterToday(daysAfterToday: Int)
 
     fun setEndTimeUpperBound(date: Date)
 

--- a/core/src/main/java/com/zeronfinity/core/repository/FilterTimeRangeRepository.kt
+++ b/core/src/main/java/com/zeronfinity/core/repository/FilterTimeRangeRepository.kt
@@ -1,5 +1,7 @@
 package com.zeronfinity.core.repository
 
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.END_TIME
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.START_TIME
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_LOWER_BOUND
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_UPPER_BOUND
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeEnum.*
@@ -16,6 +18,11 @@ class FilterTimeRangeRepository(private val filterTimeRangeDataSource: FilterTim
     enum class FilterDurationEnum {
         DURATION_LOWER_BOUND,
         DURATION_UPPER_BOUND
+    }
+
+    enum class FilterTimeTypeEnum {
+        START_TIME,
+        END_TIME
     }
 
     fun getFilterTimeRange(filterTimeEnum: FilterTimeEnum) = when (filterTimeEnum) {
@@ -45,4 +52,24 @@ class FilterTimeRangeRepository(private val filterTimeRangeDataSource: FilterTim
     fun isSaved() = filterTimeRangeDataSource.isSaved()
 
     fun setSaved(value: Boolean) = filterTimeRangeDataSource.setSaved(value)
+
+    fun isLowerBoundToday(filterTimeTypeEnum: FilterTimeTypeEnum) = when (filterTimeTypeEnum) {
+        START_TIME -> filterTimeRangeDataSource.isStartTimeLowerBoundToday()
+        END_TIME -> filterTimeRangeDataSource.isEndTimeLowerBoundToday()
+    }
+
+    fun getDaysAfterToday(filterTimeTypeEnum: FilterTimeTypeEnum) = when (filterTimeTypeEnum) {
+        START_TIME -> filterTimeRangeDataSource.getStartTimeDaysAfterToday()
+        END_TIME -> filterTimeRangeDataSource.getEndTimeDaysAfterToday()
+    }
+
+    fun setLowerBoundToday(filterTimeTypeEnum: FilterTimeTypeEnum, value: Boolean) = when (filterTimeTypeEnum) {
+        START_TIME -> filterTimeRangeDataSource.setStartTimeLowerBoundToday(value)
+        END_TIME -> filterTimeRangeDataSource.setEndTimeLowerBoundToday(value)
+    }
+
+    fun setDaysAfterToday(filterTimeTypeEnum: FilterTimeTypeEnum, value: Int) = when (filterTimeTypeEnum) {
+        START_TIME -> filterTimeRangeDataSource.setStartTimeDaysAfterToday(value)
+        END_TIME -> filterTimeRangeDataSource.setEndTimeDaysAfterToday(value)
+    }
 }

--- a/core/src/main/java/com/zeronfinity/core/usecase/GetFilterDaysAfterTodayUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/GetFilterDaysAfterTodayUseCase.kt
@@ -1,0 +1,9 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.FilterTimeRangeRepository
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum
+
+class GetFilterDaysAfterTodayUseCase(private val filterTimeRangeRepository: FilterTimeRangeRepository) {
+    operator fun invoke(filterTimeTypeEnum: FilterTimeTypeEnum) =
+        filterTimeRangeRepository.getDaysAfterToday(filterTimeTypeEnum)
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/GetFilteredContestListUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/GetFilteredContestListUseCase.kt
@@ -7,7 +7,12 @@ import com.zeronfinity.core.repository.FilterTimeRangeRepository
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeEnum.*
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_LOWER_BOUND
 import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterDurationEnum.DURATION_UPPER_BOUND
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.END_TIME
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum.START_TIME
 import com.zeronfinity.core.repository.PlatformRepository
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
 
 class GetFilteredContestListUseCase(
     private val contestRepository: ContestRepository,
@@ -18,12 +23,38 @@ class GetFilteredContestListUseCase(
         val filteredContestList = ArrayList<Contest>()
         val allContestList = contestRepository.getContestList()
 
-        val startTimeLowerBound = filterTimeRepository.getFilterTimeRange(START_TIME_LOWER_BOUND)
-        val startTimeUpperBound = filterTimeRepository.getFilterTimeRange(START_TIME_UPPER_BOUND)
-        val endTimeLowerBound = filterTimeRepository.getFilterTimeRange(END_TIME_LOWER_BOUND)
-        val endTimeUpperBound = filterTimeRepository.getFilterTimeRange(END_TIME_UPPER_BOUND)
+        var startTimeLowerBound = filterTimeRepository.getFilterTimeRange(START_TIME_LOWER_BOUND)
+        var startTimeUpperBound = filterTimeRepository.getFilterTimeRange(START_TIME_UPPER_BOUND)
+        var endTimeLowerBound = filterTimeRepository.getFilterTimeRange(END_TIME_LOWER_BOUND)
+        var endTimeUpperBound = filterTimeRepository.getFilterTimeRange(END_TIME_UPPER_BOUND)
         val durationLowerBound = filterTimeRepository.getFilterDuration(DURATION_LOWER_BOUND)
         val durationUpperBound = filterTimeRepository.getFilterDuration(DURATION_UPPER_BOUND)
+
+        if (filterTimeRepository.isLowerBoundToday(START_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+
+            startTimeLowerBound = calendar.time
+
+            calendar.add(Calendar.DAY_OF_YEAR, filterTimeRepository.getDaysAfterToday(START_TIME))
+            startTimeUpperBound = calendar.time
+        }
+
+        if (filterTimeRepository.isLowerBoundToday(END_TIME)) {
+            val calendar = GregorianCalendar.getInstance()
+            calendar.time = Date()
+            calendar.set(Calendar.HOUR_OF_DAY, 0)
+            calendar.set(Calendar.MINUTE, 0)
+            calendar.set(Calendar.SECOND, 0)
+
+            endTimeLowerBound = calendar.time
+
+            calendar.add(Calendar.DAY_OF_YEAR, filterTimeRepository.getDaysAfterToday(END_TIME))
+            endTimeUpperBound = calendar.time
+        }
 
         logD("allContestList: [$allContestList]")
         logD(

--- a/core/src/main/java/com/zeronfinity/core/usecase/IsFilterLowerBoundTodayUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/IsFilterLowerBoundTodayUseCase.kt
@@ -1,0 +1,9 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.FilterTimeRangeRepository
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum
+
+class IsFilterLowerBoundTodayUseCase(private val filterTimeRangeRepository: FilterTimeRangeRepository) {
+    operator fun invoke(filterTimeTypeEnum: FilterTimeTypeEnum) =
+        filterTimeRangeRepository.isLowerBoundToday(filterTimeTypeEnum)
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/SetFilterDaysAfterTodayUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/SetFilterDaysAfterTodayUseCase.kt
@@ -1,0 +1,9 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.FilterTimeRangeRepository
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum
+
+class SetFilterDaysAfterTodayUseCase(private val filterTimeRangeRepository: FilterTimeRangeRepository) {
+    operator fun invoke(filterTimeTypeEnum: FilterTimeTypeEnum, value: Int) =
+        filterTimeRangeRepository.setDaysAfterToday(filterTimeTypeEnum, value)
+}

--- a/core/src/main/java/com/zeronfinity/core/usecase/SetFilterLowerBoundTodayUseCase.kt
+++ b/core/src/main/java/com/zeronfinity/core/usecase/SetFilterLowerBoundTodayUseCase.kt
@@ -1,0 +1,11 @@
+package com.zeronfinity.core.usecase
+
+import com.zeronfinity.core.repository.FilterTimeRangeRepository
+import com.zeronfinity.core.repository.FilterTimeRangeRepository.FilterTimeTypeEnum
+
+class SetFilterLowerBoundTodayUseCase(private val filterTimeRangeRepository: FilterTimeRangeRepository) {
+    operator fun invoke(
+        filterTimeTypeEnum: FilterTimeTypeEnum,
+        value: Boolean
+    ) = filterTimeRangeRepository.setLowerBoundToday(filterTimeTypeEnum, value)
+}


### PR DESCRIPTION
## Title

[Task: Add filter functionality to use lower bound as start of current date](https://github.com/Zeronfinity/CPfy/issues/52)

### Changes made

- Added 'Today' checkbox below lower bounds of start time and end time in filter page
- Added option to set number of days after today for end time

### How does this PR address the issue

This PR will allow user to quickly see/use all contests of a certain day.

### Linked issues

Resolves #52