### PR TITLE
Fix negative contest start time due to contest ending

### DIFF
--- a/app/src/main/java/com/zeronfinity/cpfy/view/adapter/AdapterContestList.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/adapter/AdapterContestList.kt
@@ -41,51 +41,74 @@ class AdapterContestList @Inject constructor(
                 Locale.getDefault()
             ).format(contest.startTime)
 
-            val diffInMillis = contest.startTime.time - Date().time
-            if (diffInMillis < 0) {
-                binding.tvTimeLeft.text =
-                    binding.tvTimeLeft.context.getString(R.string.contest_already_started)
-                binding.tvTimeLeft.setTextColor(
-                    ContextCompat.getColor(
-                        binding.tvTimeLeft.context,
-                        R.color.primaryTextColor
+            when {
+                contest.endTime.time < Date().time -> {
+                    binding.tvTimeLeft.text =
+                        binding.tvTimeLeft.context.getString(R.string.contest_already_ended)
+                    binding.tvTimeLeft.setTextColor(
+                        ContextCompat.getColor(
+                            binding.tvTimeLeft.context,
+                            R.color.primaryTextColor
+                        )
                     )
-                )
 
-                binding.tvStartsOnLabel.text = binding.tvStartsOnLabel.context.getString(
-                    R.string.started_at_colon_tv_label
-                )
-                binding.tvDurationLabel.text = binding.tvDurationLabel.context.getString(
-                    R.string.time_left_colon_tv_label
-                )
-                binding.tvDuration.text =
-                    parseSecondsToString(
-                        contest.duration.toLong() + diffInMillis / 1000
+                    binding.tvStartsOnLabel.text = binding.tvStartsOnLabel.context.getString(
+                        R.string.started_at_colon_tv_label
                     )
-            } else {
-                binding.tvTimeLeft.text = binding.tvTimeLeft.context.getString(
-                    R.string.time_left_to_start,
-                    parseSecondsToString(
-                        diffInMillis / 1000
+                    binding.tvDurationLabel.text = binding.tvDurationLabel.context.getString(
+                        R.string.duration_colon_tv_label
                     )
-                )
-                binding.tvTimeLeft.setTextColor(
-                    ContextCompat.getColor(
-                        binding.tvTimeLeft.context,
-                        R.color.primaryDarkColor
+                    binding.tvDuration.text =
+                        parseSecondsToString(
+                            contest.duration.toLong()
+                        )
+                }
+                contest.startTime.time < Date().time -> {
+                    binding.tvTimeLeft.text =
+                        binding.tvTimeLeft.context.getString(R.string.contest_already_started)
+                    binding.tvTimeLeft.setTextColor(
+                        ContextCompat.getColor(
+                            binding.tvTimeLeft.context,
+                            R.color.primaryTextColor
+                        )
                     )
-                )
 
-                binding.tvStartsOnLabel.text = binding.tvStartsOnLabel.context.getString(
-                    R.string.starts_at_colon_tv_label
-                )
-                binding.tvDurationLabel.text = binding.tvDurationLabel.context.getString(
-                    R.string.duration_colon_tv_label
-                )
-                binding.tvDuration.text =
-                    parseSecondsToString(
-                        contest.duration.toLong()
+                    binding.tvStartsOnLabel.text = binding.tvStartsOnLabel.context.getString(
+                        R.string.started_at_colon_tv_label
                     )
+                    binding.tvDurationLabel.text = binding.tvDurationLabel.context.getString(
+                        R.string.time_left_colon_tv_label
+                    )
+                    binding.tvDuration.text =
+                        parseSecondsToString(
+                            contest.duration.toLong() + (contest.startTime.time - Date().time) / 1000
+                        )
+                }
+                else -> {
+                    binding.tvTimeLeft.text = binding.tvTimeLeft.context.getString(
+                        R.string.time_left_to_start,
+                        parseSecondsToString(
+                            (contest.startTime.time - Date().time) / 1000
+                        )
+                    )
+                    binding.tvTimeLeft.setTextColor(
+                        ContextCompat.getColor(
+                            binding.tvTimeLeft.context,
+                            R.color.primaryDarkColor
+                        )
+                    )
+
+                    binding.tvStartsOnLabel.text = binding.tvStartsOnLabel.context.getString(
+                        R.string.starts_at_colon_tv_label
+                    )
+                    binding.tvDurationLabel.text = binding.tvDurationLabel.context.getString(
+                        R.string.duration_colon_tv_label
+                    )
+                    binding.tvDuration.text =
+                        parseSecondsToString(
+                            contest.duration.toLong()
+                        )
+                }
             }
 
             coroutineScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="time_left_colon_tv_label">Time left:</string>
     <string name="time_left_to_start">%s to start</string>
     <string name="contest_already_started">Contest already started!</string>
+    <string name="contest_already_ended">Contest already ended!</string>
 
     <!-- fragment_filters string -->
     <string name="time_filters_heading">Press a date/time to change it</string>


### PR DESCRIPTION
## Title

[Time left is showing negative time](https://github.com/Zeronfinity/CPfy/issues/56)

### Changes made

- Added feature to show contest ended instead of showing negative time left.
<img alt="Screenshot_1610818653" src="https://user-images.githubusercontent.com/34229687/104818759-d2607a00-5853-11eb-993e-649517c92089.png"  width=400>


### How does this PR address the issue

This PR will fix ended contests showing negative time left.

### Linked issues

Resolves #56