### PR TITLE
Add swipe/pull down functionality to reload contest list page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+
 
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
 

--- a/app/src/main/java/com/zeronfinity/cpfy/broadcast/NotificationBroadcast.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/broadcast/NotificationBroadcast.kt
@@ -42,7 +42,7 @@ class NotificationBroadcast : BroadcastReceiver() {
                 coroutineScope.launch {
                     getContestUseCase(contestId)?.let { contest ->
                         getPlatformUseCase(contest.platformId)?.let { platform->
-                            if (platform.notificationPriority != "None") {
+                            if (platform.notificationPriority != "Hide") {
                                 notificationHelper.createNotificationChannel(
                                     "ch-${platform.id}",
                                     platform.shortName,

--- a/app/src/main/java/com/zeronfinity/cpfy/common/UtilityFunctions.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/common/UtilityFunctions.kt
@@ -27,8 +27,8 @@ fun createNotificationAlarm(context: Context, contest: Contest) {
     )
 }
 
-fun makeDurationText(duration: Int): String {
-    var remainingDuration = duration / 60
+fun makeDurationText(durationInSeconds: Int): String {
+    var remainingDuration = durationInSeconds / 60
 
     val minutes = remainingDuration % 60
     remainingDuration /= 60
@@ -58,6 +58,50 @@ fun makeDurationText(duration: Int): String {
         text += " "
     }
     text += "${minutes}m"
+
+    return text
+}
+
+fun makeFullDurationText(durationInSeconds: Long): String {
+    var remainingDuration = durationInSeconds / 60
+
+    val minutes = remainingDuration % 60
+    remainingDuration /= 60
+
+    val hours = remainingDuration % 24
+    remainingDuration /= 24
+
+    val days = remainingDuration
+
+    var text = ""
+
+    if (days != 0L) {
+        if (text.isNotEmpty()) {
+            text += " "
+        }
+        text += "$days day"
+        if (days > 1) {
+            text += "s"
+        }
+    }
+
+    if (hours != 0L || text.isNotEmpty()) {
+        if (text.isNotEmpty()) {
+            text += " "
+        }
+        text += "$hours hour"
+        if (hours > 1) {
+            text += "s"
+        }
+    }
+
+    if (text.isNotEmpty()) {
+        text += " "
+    }
+    text += "$minutes minute"
+    if (minutes > 1) {
+        text += "s"
+    }
 
     return text
 }

--- a/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/ContestListFragment.kt
@@ -95,6 +95,10 @@ class ContestListFragment : BaseFragment() {
             prevDurationUpperBound = it.getInt("DURATION_UPPER_BOUND")
         }
 
+        binding.swipeRefresh.setOnRefreshListener {
+            contestListViewModel.fetchContestList()
+        }
+
         if (isFirstTime || isTimeFilterChanged()) {
             contestListViewModel.fetchContestList()
         }
@@ -120,16 +124,19 @@ class ContestListFragment : BaseFragment() {
                         .show()
                 }
             }
+            binding.swipeRefresh.isRefreshing = false
         })
 
         contestListViewModel.contestListLiveData.observe(viewLifecycleOwner, {
             logD("contestListLiveData -> contestList:[$it]")
             adapterContestList.refreshContestList(it)
+            binding.swipeRefresh.isRefreshing = false
         })
 
         contestListViewModel.contestListLiveDataFlow.observe(viewLifecycleOwner, {
             logD("contestListLiveDataFlow -> contestList:[$it]")
             adapterContestList.refreshContestList(it)
+            binding.swipeRefresh.isRefreshing = false
         })
 
         contestListViewModel.platformListLiveData.observe(viewLifecycleOwner, {
@@ -148,7 +155,6 @@ class ContestListFragment : BaseFragment() {
             }
         })
     }
-
 
     private fun isTimeFilterChanged(): Boolean {
         var isChanged = false

--- a/app/src/main/java/com/zeronfinity/cpfy/view/adapter/AdapterContestList.kt
+++ b/app/src/main/java/com/zeronfinity/cpfy/view/adapter/AdapterContestList.kt
@@ -14,6 +14,7 @@ import com.zeronfinity.core.entity.Contest
 import com.zeronfinity.core.logger.logD
 import com.zeronfinity.core.usecase.GetPlatformUseCase
 import com.zeronfinity.cpfy.R
+import com.zeronfinity.cpfy.common.makeFullDurationText
 import com.zeronfinity.cpfy.databinding.ItemContestBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,7 +60,7 @@ class AdapterContestList @Inject constructor(
                         R.string.duration_colon_tv_label
                     )
                     binding.tvDuration.text =
-                        parseSecondsToString(
+                        makeFullDurationText(
                             contest.duration.toLong()
                         )
                 }
@@ -80,14 +81,14 @@ class AdapterContestList @Inject constructor(
                         R.string.time_left_colon_tv_label
                     )
                     binding.tvDuration.text =
-                        parseSecondsToString(
+                        makeFullDurationText(
                             contest.duration.toLong() + (contest.startTime.time - Date().time) / 1000
                         )
                 }
                 else -> {
                     binding.tvTimeLeft.text = binding.tvTimeLeft.context.getString(
                         R.string.time_left_to_start,
-                        parseSecondsToString(
+                        makeFullDurationText(
                             (contest.startTime.time - Date().time) / 1000
                         )
                     )
@@ -105,7 +106,7 @@ class AdapterContestList @Inject constructor(
                         R.string.duration_colon_tv_label
                     )
                     binding.tvDuration.text =
-                        parseSecondsToString(
+                        makeFullDurationText(
                             contest.duration.toLong()
                         )
                 }
@@ -164,27 +165,5 @@ class AdapterContestList @Inject constructor(
         contestList.clear()
         contestList.addAll(list)
         notifyDataSetChanged()
-    }
-
-    private fun parseSecondsToString(durationInSeconds: Long): String {
-        val minutes = (durationInSeconds / 60) % 60
-        val hours = (durationInSeconds / 60 / 60) % 24
-        val days = durationInSeconds / 60 / 60 / 24
-        var ret = ""
-        if (days != 0L) {
-            ret += "$days day"
-            if (days > 1) ret += "s"
-        }
-        if (hours != 0L) {
-            if (ret.isNotEmpty()) ret += " "
-            ret += "$hours hour"
-            if (hours > 1) ret += "s"
-        }
-        if (minutes != 0L) {
-            if (ret.isNotEmpty()) ret += " "
-            ret += "$minutes minute"
-            if (minutes > 1) ret += "s"
-        }
-        return ret
     }
 }

--- a/app/src/main/res/layout/fragment_contest_list.xml
+++ b/app/src/main/res/layout/fragment_contest_list.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/rvContestList"
+    android:id="@+id/swipeRefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scrollbars="none"
-    tools:context=".view.ContestListFragment" />
+    tools:context=".view.ContestListFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvContestList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="none" />
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
## Title

[Feature: Refresh feature](https://github.com/Zeronfinity/CPfy/issues/57)

### Changes made

- Added swipe-to-refresh functionality
- Fixed 0 duration not showing in contest list screen

### How does this PR address the issue

This PR will allow swiping down or pulling down to force reload contest list page for current filters.

### Linked issues

Resolves #57